### PR TITLE
feat: add CA certificate TLS support for GHES connections

### DIFF
--- a/__tests__/preflight-command.test.ts
+++ b/__tests__/preflight-command.test.ts
@@ -25,6 +25,11 @@ vi.mock('../src/service.js', () => {
   };
 });
 
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+}));
+import * as fs from 'fs';
+
 import { createLogger } from '../src/logger.js';
 import { createAuthConfig } from '../src/auth.js';
 import { createOctokit } from '../src/octokit.js';
@@ -318,6 +323,82 @@ describe('preflight-command', () => {
       });
     });
 
+    describe('CA certificate TLS', () => {
+      it('should use cert dispatcher when caCertPath is provided', async () => {
+        vi.mocked(fs.readFileSync).mockReturnValue(
+          '-----BEGIN CERTIFICATE-----\ncert-data\n-----END CERTIFICATE-----\n',
+        );
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://ghes.example.com/api/v3',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+          caCertPath: '/path/to/ca.pem',
+          skipTlsVerification: false,
+        });
+
+        // Cert is used; global TLS bypass must NOT be set
+        expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+        // Dispatcher was passed to createOctokit as the 6th arg
+        expect(createOctokit).toHaveBeenCalledWith(
+          expect.anything(),
+          'https://ghes.example.com/api/v3',
+          undefined,
+          expect.anything(),
+          undefined,
+          expect.objectContaining({}), // the undici Agent dispatcher
+        );
+        expect(consoleLogSpy).toHaveBeenCalledWith('ca_cert_used=true');
+        expect(consoleLogSpy).toHaveBeenCalledWith('ssl_verify_disabled=false');
+      });
+
+      it('should read GHES_CA_CERT_PATH env var automatically', async () => {
+        process.env['GHES_CA_CERT_PATH'] = '/env/ca.pem';
+        vi.mocked(fs.readFileSync).mockReturnValue('cert-data');
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://ghes.example.com/api/v3',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+          skipTlsVerification: false,
+        });
+
+        expect(fs.readFileSync).toHaveBeenCalledWith('/env/ca.pem', 'utf8');
+        expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+        expect(consoleLogSpy).toHaveBeenCalledWith('ca_cert_used=true');
+      });
+
+      it('should fall back to SSL bypass when cert file is missing and skipTlsVerification is true', async () => {
+        vi.mocked(fs.readFileSync).mockImplementation(() => {
+          throw new Error('ENOENT: no such file or directory');
+        });
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://ghes.example.com/api/v3',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+          caCertPath: '/missing/ca.pem',
+          skipTlsVerification: true,
+        });
+
+        expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
+        expect(consoleLogSpy).toHaveBeenCalledWith('ca_cert_used=false');
+        expect(consoleLogSpy).toHaveBeenCalledWith('ssl_verify_disabled=true');
+      });
+    });
+
     describe('authenticated client creation', () => {
       it('should create Octokit with auth config and base URL', async () => {
         mockClient.validateOrganization.mockResolvedValue({
@@ -348,6 +429,8 @@ describe('preflight-command', () => {
           'https://ghes.example.com/api/v3',
           undefined,
           expect.anything(),
+          undefined,
+          undefined,
         );
       });
     });
@@ -374,6 +457,7 @@ describe('preflight-command', () => {
       expect(optionNames).toContain('--app-id');
       expect(optionNames).toContain('--private-key');
       expect(optionNames).toContain('--app-installation-id');
+      expect(optionNames).toContain('--ca-cert-path');
     });
   });
 });

--- a/__tests__/preflight-command.test.ts
+++ b/__tests__/preflight-command.test.ts
@@ -172,6 +172,19 @@ describe('preflight-command', () => {
         );
       });
 
+      it('should throw when org-name is missing for repository type', async () => {
+        await expect(
+          runPreflight({
+            baseUrl: 'https://api.github.com',
+            type: 'repository',
+            repository: 'test-repo',
+            accessToken: 'token-123',
+          }),
+        ).rejects.toThrow(
+          /An organization name is required when type is 'repository'/,
+        );
+      });
+
       it('should throw on repository not found (404)', async () => {
         mockClient.validateRepository.mockRejectedValue(
           new Error('Repository not found: test-org/nonexistent'),

--- a/__tests__/preflight-command.test.ts
+++ b/__tests__/preflight-command.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createMockLogger } from './test-utils.js';
+
+// Mock dependencies
+vi.mock('../src/logger.js', () => ({
+  createLogger: vi.fn(),
+}));
+
+vi.mock('../src/auth.js', () => ({
+  createAuthConfig: vi.fn().mockReturnValue({
+    authStrategy: undefined,
+    auth: 'test-token',
+  }),
+}));
+
+vi.mock('../src/octokit.js', () => ({
+  createOctokit: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../src/service.js', () => {
+  const MockOctokitClient = vi.fn();
+  return {
+    OctokitClient: MockOctokitClient,
+    DEFAULT_API_VERSION: '2022-11-28',
+  };
+});
+
+import { createLogger } from '../src/logger.js';
+import { createAuthConfig } from '../src/auth.js';
+import { createOctokit } from '../src/octokit.js';
+import { OctokitClient } from '../src/service.js';
+import { runPreflight } from '../src/commands/preflight-command.js';
+
+describe('preflight-command', () => {
+  const mockLogger = createMockLogger();
+  let originalEnv: typeof process.env;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let mockClient: {
+    validateRepository: ReturnType<typeof vi.fn>;
+    validateOrganization: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    mockClient = {
+      validateRepository: vi.fn(),
+      validateOrganization: vi.fn(),
+    };
+    vi.mocked(createLogger).mockResolvedValue(mockLogger as any);
+    vi.mocked(createAuthConfig).mockReturnValue({
+      authStrategy: undefined,
+      auth: 'test-token',
+    });
+    vi.mocked(createOctokit).mockReturnValue({} as any);
+    vi.mocked(OctokitClient).mockImplementation(function () {
+      return mockClient as unknown as InstanceType<typeof OctokitClient>;
+    });
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(createOctokit).mockClear();
+    vi.mocked(createAuthConfig).mockClear();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('runPreflight', () => {
+    describe('host resolution', () => {
+      it('should resolve github.com from api.github.com', async () => {
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://api.github.com',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+        });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('gh_host=github.com');
+        expect(consoleLogSpy).toHaveBeenCalledWith('is_github_com=true');
+      });
+
+      it('should resolve GHES hostname', async () => {
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://ghes.example.com/api/v3',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+        });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('gh_host=ghes.example.com');
+        expect(consoleLogSpy).toHaveBeenCalledWith('is_github_com=false');
+      });
+    });
+
+    describe('TLS bypass', () => {
+      it('should configure TLS bypass for GHES when requested', async () => {
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://ghes.example.com/api/v3',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+          skipTlsVerification: true,
+        });
+
+        expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
+        expect(consoleLogSpy).toHaveBeenCalledWith('ssl_verify_disabled=true');
+      });
+
+      it('should reject TLS bypass for github.com', async () => {
+        await expect(
+          runPreflight({
+            baseUrl: 'https://api.github.com',
+            type: 'organization',
+            orgName: 'test-org',
+            accessToken: 'token-123',
+            skipTlsVerification: true,
+          }),
+        ).rejects.toThrow(
+          /Refusing to disable TLS verification for public github.com/,
+        );
+      });
+
+      it('should not configure TLS bypass when not requested', async () => {
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://ghes.example.com/api/v3',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+          skipTlsVerification: false,
+        });
+
+        expect(consoleLogSpy).toHaveBeenCalledWith('ssl_verify_disabled=false');
+      });
+    });
+
+    describe('repository validation', () => {
+      it('should validate repository exists', async () => {
+        mockClient.validateRepository.mockResolvedValue({
+          fullName: 'test-org/test-repo',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://api.github.com',
+          type: 'repository',
+          orgName: 'test-org',
+          repository: 'test-repo',
+          accessToken: 'token-123',
+        });
+
+        expect(mockClient.validateRepository).toHaveBeenCalledWith(
+          'test-org',
+          'test-repo',
+        );
+      });
+
+      it('should throw on repository not found (404)', async () => {
+        mockClient.validateRepository.mockRejectedValue(
+          new Error('Repository not found: test-org/nonexistent'),
+        );
+
+        await expect(
+          runPreflight({
+            baseUrl: 'https://api.github.com',
+            type: 'repository',
+            orgName: 'test-org',
+            repository: 'nonexistent',
+            accessToken: 'token-123',
+          }),
+        ).rejects.toThrow(/Repository not found: test-org\/nonexistent/);
+      });
+
+      it('should throw on repository API error', async () => {
+        mockClient.validateRepository.mockRejectedValue(
+          new Error(
+            'Failed to validate repository test-org/test-repo: Network error',
+          ),
+        );
+
+        await expect(
+          runPreflight({
+            baseUrl: 'https://api.github.com',
+            type: 'repository',
+            orgName: 'test-org',
+            repository: 'test-repo',
+            accessToken: 'token-123',
+          }),
+        ).rejects.toThrow(/Failed to validate repository/);
+      });
+    });
+
+    describe('organization validation', () => {
+      it('should validate organization exists for org type', async () => {
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://api.github.com',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+        });
+
+        expect(mockClient.validateOrganization).toHaveBeenCalledWith(
+          'test-org',
+        );
+      });
+
+      it('should validate organization for project-stats type', async () => {
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://api.github.com',
+          type: 'project-stats',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+        });
+
+        expect(mockClient.validateOrganization).toHaveBeenCalledWith(
+          'test-org',
+        );
+      });
+
+      it('should throw on organization not found (404)', async () => {
+        mockClient.validateOrganization.mockRejectedValue(
+          new Error('Organization not found: nonexistent-org'),
+        );
+
+        await expect(
+          runPreflight({
+            baseUrl: 'https://api.github.com',
+            type: 'organization',
+            orgName: 'nonexistent-org',
+            accessToken: 'token-123',
+          }),
+        ).rejects.toThrow(/Organization not found: nonexistent-org/);
+      });
+
+      it('should throw on organization API error', async () => {
+        mockClient.validateOrganization.mockRejectedValue(
+          new Error(
+            'Failed to validate organization test-org: Connection refused',
+          ),
+        );
+
+        await expect(
+          runPreflight({
+            baseUrl: 'https://api.github.com',
+            type: 'organization',
+            orgName: 'test-org',
+            accessToken: 'token-123',
+          }),
+        ).rejects.toThrow(/Failed to validate organization/);
+      });
+    });
+
+    describe('combine type', () => {
+      it('should skip validation for combine type', async () => {
+        await runPreflight({
+          baseUrl: 'https://api.github.com',
+          type: 'combine',
+        });
+
+        expect(createOctokit).not.toHaveBeenCalled();
+        expect(mockClient.validateRepository).not.toHaveBeenCalled();
+        expect(mockClient.validateOrganization).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('app-install-stats auth validation', () => {
+      it('should succeed with access token for app-install-stats', async () => {
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await expect(
+          runPreflight({
+            baseUrl: 'https://api.github.com',
+            type: 'app-install-stats',
+            orgName: 'test-org',
+            accessToken: 'pat-token',
+          }),
+        ).resolves.not.toThrow();
+      });
+    });
+
+    describe('authenticated client creation', () => {
+      it('should create Octokit with auth config and base URL', async () => {
+        mockClient.validateOrganization.mockResolvedValue({
+          login: 'test-org',
+        });
+
+        await runPreflight({
+          baseUrl: 'https://ghes.example.com/api/v3',
+          type: 'organization',
+          orgName: 'test-org',
+          accessToken: 'token-123',
+          appId: 'app-123',
+          privateKey: 'key-123',
+          appInstallationId: 'install-123',
+        });
+
+        expect(createAuthConfig).toHaveBeenCalledWith(
+          expect.objectContaining({
+            accessToken: 'token-123',
+            appId: 'app-123',
+            privateKey: 'key-123',
+            appInstallationId: 'install-123',
+          }),
+        );
+
+        expect(createOctokit).toHaveBeenCalledWith(
+          expect.anything(),
+          'https://ghes.example.com/api/v3',
+          undefined,
+          expect.anything(),
+        );
+      });
+    });
+  });
+
+  describe('command definition', () => {
+    it('should be defined with correct name', async () => {
+      const { default: preflightCommand } =
+        await import('../src/commands/preflight-command.js');
+      expect(preflightCommand.name()).toBe('preflight');
+    });
+
+    it('should have required options', async () => {
+      const { default: preflightCommand } =
+        await import('../src/commands/preflight-command.js');
+      const optionNames = preflightCommand.options.map((opt: any) => opt.long);
+
+      expect(optionNames).toContain('--base-url');
+      expect(optionNames).toContain('--skip-tls-verification');
+      expect(optionNames).toContain('--org-name');
+      expect(optionNames).toContain('--repository');
+      expect(optionNames).toContain('--type');
+      expect(optionNames).toContain('--access-token');
+      expect(optionNames).toContain('--app-id');
+      expect(optionNames).toContain('--private-key');
+      expect(optionNames).toContain('--app-installation-id');
+    });
+  });
+});

--- a/__tests__/service.test.ts
+++ b/__tests__/service.test.ts
@@ -22,6 +22,10 @@ describe('OctokitClient', () => {
       rest: {
         repos: {
           listForOrg: vi.fn(),
+          get: vi.fn(),
+        },
+        orgs: {
+          get: vi.fn(),
         },
       },
       auth: vi.fn(),
@@ -79,6 +83,95 @@ describe('OctokitClient', () => {
 
       // Act & Assert
       await expect(client.generateAppToken()).rejects.toThrow(errorMessage);
+    });
+  });
+
+  describe('validateRepository', () => {
+    it('should return fullName when repository exists', async () => {
+      mockOctokit.rest.repos.get.mockResolvedValue({
+        data: { full_name: 'test-org/test-repo' },
+      });
+
+      const result = await client.validateRepository('test-org', 'test-repo');
+
+      expect(result).toEqual({ fullName: 'test-org/test-repo' });
+      expect(mockOctokit.rest.repos.get).toHaveBeenCalledWith({
+        owner: 'test-org',
+        repo: 'test-repo',
+        headers: { 'X-GitHub-Api-Version': '2022-11-28' },
+      });
+    });
+
+    it('should throw with clear message on 404', async () => {
+      mockOctokit.rest.repos.get.mockRejectedValue({ status: 404 });
+
+      await expect(
+        client.validateRepository('test-org', 'nonexistent'),
+      ).rejects.toThrow(/Repository not found: test-org\/nonexistent/);
+    });
+
+    it('should throw with cause on 404', async () => {
+      const original = { status: 404 };
+      mockOctokit.rest.repos.get.mockRejectedValue(original);
+
+      try {
+        await client.validateRepository('test-org', 'nonexistent');
+      } catch (error: unknown) {
+        expect((error as Error).cause).toBe(original);
+      }
+    });
+
+    it('should throw on non-404 API errors', async () => {
+      mockOctokit.rest.repos.get.mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        client.validateRepository('test-org', 'test-repo'),
+      ).rejects.toThrow(/Failed to validate repository test-org\/test-repo/);
+    });
+  });
+
+  describe('validateOrganization', () => {
+    it('should return login when organization exists', async () => {
+      mockOctokit.rest.orgs.get.mockResolvedValue({
+        data: { login: 'test-org' },
+      });
+
+      const result = await client.validateOrganization('test-org');
+
+      expect(result).toEqual({ login: 'test-org' });
+      expect(mockOctokit.rest.orgs.get).toHaveBeenCalledWith({
+        org: 'test-org',
+        headers: { 'X-GitHub-Api-Version': '2022-11-28' },
+      });
+    });
+
+    it('should throw with clear message on 404', async () => {
+      mockOctokit.rest.orgs.get.mockRejectedValue({ status: 404 });
+
+      await expect(
+        client.validateOrganization('nonexistent-org'),
+      ).rejects.toThrow(/Organization not found: nonexistent-org/);
+    });
+
+    it('should throw with cause on 404', async () => {
+      const original = { status: 404 };
+      mockOctokit.rest.orgs.get.mockRejectedValue(original);
+
+      try {
+        await client.validateOrganization('nonexistent-org');
+      } catch (error: unknown) {
+        expect((error as Error).cause).toBe(original);
+      }
+    });
+
+    it('should throw on non-404 API errors', async () => {
+      mockOctokit.rest.orgs.get.mockRejectedValue(
+        new Error('Connection refused'),
+      );
+
+      await expect(client.validateOrganization('test-org')).rejects.toThrow(
+        /Failed to validate organization test-org/,
+      );
     });
   });
 

--- a/__tests__/tls.test.ts
+++ b/__tests__/tls.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { configureSslBypass, TlsBypassError } from '../src/tls.js';
+import { createMockLogger } from './test-utils.js';
+
+describe('tls', () => {
+  const mockLogger = createMockLogger();
+  let originalEnv: typeof process.env;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('configureSslBypass', () => {
+    it('should set NODE_TLS_REJECT_UNAUTHORIZED to 0', () => {
+      configureSslBypass('https://ghes.example.com/api/v3', mockLogger);
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
+    });
+
+    it('should set GIT_SSL_NO_VERIFY to 1', () => {
+      configureSslBypass('https://ghes.example.com/api/v3', mockLogger);
+      expect(process.env.GIT_SSL_NO_VERIFY).toBe('1');
+    });
+
+    it('should set NODE_NO_WARNINGS to 1', () => {
+      configureSslBypass('https://ghes.example.com/api/v3', mockLogger);
+      expect(process.env.NODE_NO_WARNINGS).toBe('1');
+    });
+
+    it('should throw TlsBypassError for api.github.com', () => {
+      expect(() =>
+        configureSslBypass('https://api.github.com', mockLogger),
+      ).toThrow(TlsBypassError);
+    });
+
+    it('should throw TlsBypassError for github.com base URL', () => {
+      expect(() =>
+        configureSslBypass('https://github.com', mockLogger),
+      ).toThrow(TlsBypassError);
+    });
+
+    it('should include helpful message when refusing github.com', () => {
+      expect(() =>
+        configureSslBypass('https://api.github.com', mockLogger),
+      ).toThrow(/Refusing to disable TLS verification for public github.com/);
+    });
+
+    it('should allow TLS bypass for GHES URLs', () => {
+      expect(() =>
+        configureSslBypass('https://ghes.corp.example.com/api/v3', mockLogger),
+      ).not.toThrow();
+    });
+
+    it('should allow TLS bypass for IP-based URLs', () => {
+      expect(() =>
+        configureSslBypass('https://10.0.0.1/api/v3', mockLogger),
+      ).not.toThrow();
+    });
+
+    it('should log info messages', () => {
+      configureSslBypass('https://ghes.example.com', mockLogger);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Disabling SSL verification for GHES connection',
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'SSL bypass configured for Node.js and Git',
+      );
+    });
+  });
+});

--- a/__tests__/tls.test.ts
+++ b/__tests__/tls.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { configureSslBypass, TlsBypassError } from '../src/tls.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  configureSslBypass,
+  createCaCertDispatcher,
+  resolveTlsDispatcher,
+  TlsBypassError,
+} from '../src/tls.js';
 import { createMockLogger } from './test-utils.js';
+
+vi.mock('fs');
+import * as fs from 'fs';
 
 describe('tls', () => {
   const mockLogger = createMockLogger();
@@ -8,10 +16,13 @@ describe('tls', () => {
 
   beforeEach(() => {
     originalEnv = { ...process.env };
+    delete process.env['GHES_CA_CERT_PATH'];
+    vi.mocked(fs.readFileSync).mockClear();
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    vi.restoreAllMocks();
   });
 
   describe('configureSslBypass', () => {
@@ -68,6 +79,121 @@ describe('tls', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         'SSL bypass configured for Node.js',
       );
+    });
+
+    it('should emit a warning recommending CA cert', () => {
+      configureSslBypass('https://ghes.example.com', mockLogger);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('GHES_CA_CERT_PATH'),
+      );
+    });
+  });
+
+  describe('createCaCertDispatcher', () => {
+    it('should return an undici Agent when cert file is readable', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        '-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----\n',
+      );
+      const dispatcher = createCaCertDispatcher(
+        '/path/to/cert.pem',
+        mockLogger,
+      );
+      expect(dispatcher).toBeDefined();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Using CA certificate for TLS verification',
+      );
+    });
+
+    it('should return undefined and warn when cert file cannot be read', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory');
+      });
+      const dispatcher = createCaCertDispatcher(
+        '/missing/cert.pem',
+        mockLogger,
+      );
+      expect(dispatcher).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to read CA certificate'),
+      );
+    });
+
+    it('should not modify NODE_TLS_REJECT_UNAUTHORIZED', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('cert-data');
+      createCaCertDispatcher('/path/to/cert.pem', mockLogger);
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+    });
+  });
+
+  describe('resolveTlsDispatcher', () => {
+    it('should return a dispatcher when caCertPath argument is provided', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue('cert-data');
+      const dispatcher = resolveTlsDispatcher(
+        'https://ghes.example.com/api/v3',
+        false,
+        mockLogger,
+        '/path/to/cert.pem',
+      );
+      expect(dispatcher).toBeDefined();
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+    });
+
+    it('should read GHES_CA_CERT_PATH from env when no explicit path given', () => {
+      process.env['GHES_CA_CERT_PATH'] = '/env/cert.pem';
+      vi.mocked(fs.readFileSync).mockReturnValue('cert-data');
+      const dispatcher = resolveTlsDispatcher(
+        'https://ghes.example.com/api/v3',
+        false,
+        mockLogger,
+      );
+      expect(dispatcher).toBeDefined();
+      expect(fs.readFileSync).toHaveBeenCalledWith('/env/cert.pem', 'utf8');
+    });
+
+    it('should fall back to SSL bypass when cert read fails and skipTlsVerification is true', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      const dispatcher = resolveTlsDispatcher(
+        'https://ghes.example.com/api/v3',
+        true,
+        mockLogger,
+        '/missing/cert.pem',
+      );
+      expect(dispatcher).toBeUndefined();
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
+    });
+
+    it('should use SSL bypass when no cert path and skipTlsVerification is true', () => {
+      const dispatcher = resolveTlsDispatcher(
+        'https://ghes.example.com/api/v3',
+        true,
+        mockLogger,
+      );
+      expect(dispatcher).toBeUndefined();
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
+    });
+
+    it('should return undefined and not bypass when no cert and skipTlsVerification is false', () => {
+      const dispatcher = resolveTlsDispatcher(
+        'https://ghes.example.com/api/v3',
+        false,
+        mockLogger,
+      );
+      expect(dispatcher).toBeUndefined();
+      expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+    });
+
+    it('should not use cert for github.com even if GHES_CA_CERT_PATH is set', () => {
+      process.env['GHES_CA_CERT_PATH'] = '/env/cert.pem';
+      vi.mocked(fs.readFileSync).mockReturnValue('cert-data');
+      const dispatcher = resolveTlsDispatcher(
+        'https://api.github.com',
+        false,
+        mockLogger,
+      );
+      expect(dispatcher).toBeUndefined();
+      expect(fs.readFileSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/tls.test.ts
+++ b/__tests__/tls.test.ts
@@ -20,9 +20,9 @@ describe('tls', () => {
       expect(process.env.NODE_TLS_REJECT_UNAUTHORIZED).toBe('0');
     });
 
-    it('should set GIT_SSL_NO_VERIFY to 1', () => {
+    it('should not set GIT_SSL_NO_VERIFY (handled by action.yml with host scoping)', () => {
       configureSslBypass('https://ghes.example.com/api/v3', mockLogger);
-      expect(process.env.GIT_SSL_NO_VERIFY).toBe('1');
+      expect(process.env.GIT_SSL_NO_VERIFY).toBeUndefined();
     });
 
     it('should set NODE_NO_WARNINGS to 1', () => {
@@ -66,7 +66,7 @@ describe('tls', () => {
         'Disabling SSL verification for GHES connection',
       );
       expect(mockLogger.info).toHaveBeenCalledWith(
-        'SSL bypass configured for Node.js and Git',
+        'SSL bypass configured for Node.js',
       );
     });
   });

--- a/__tests__/url-utils.test.ts
+++ b/__tests__/url-utils.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  apiUrlToBaseUrl,
+  hostnameFromApiUrl,
+  isGitHubDotCom,
+} from '../src/url-utils.js';
+
+describe('url-utils', () => {
+  describe('apiUrlToBaseUrl', () => {
+    it('should convert api.github.com to github.com', () => {
+      expect(apiUrlToBaseUrl('https://api.github.com')).toBe(
+        'https://github.com',
+      );
+    });
+
+    it('should strip trailing path from api.github.com', () => {
+      expect(apiUrlToBaseUrl('https://api.github.com/v3')).toBe(
+        'https://github.com',
+      );
+    });
+
+    it('should keep GHES hostname as-is', () => {
+      expect(apiUrlToBaseUrl('https://ghes.example.com/api/v3')).toBe(
+        'https://ghes.example.com',
+      );
+    });
+
+    it('should handle GHES URL without path', () => {
+      expect(apiUrlToBaseUrl('https://ghes.example.com')).toBe(
+        'https://ghes.example.com',
+      );
+    });
+
+    it('should handle IP-based URLs', () => {
+      expect(apiUrlToBaseUrl('https://10.0.0.1/api/v3')).toBe(
+        'https://10.0.0.1',
+      );
+    });
+
+    it('should handle IP-based URL with port', () => {
+      expect(apiUrlToBaseUrl('https://10.0.0.1:8443/api/v3')).toBe(
+        'https://10.0.0.1:8443',
+      );
+    });
+
+    it('should strip api. prefix from any hostname', () => {
+      expect(apiUrlToBaseUrl('https://api.ghes.example.com')).toBe(
+        'https://ghes.example.com',
+      );
+    });
+  });
+
+  describe('hostnameFromApiUrl', () => {
+    it('should return github.com for api.github.com', () => {
+      expect(hostnameFromApiUrl('https://api.github.com')).toBe('github.com');
+    });
+
+    it('should return GHES hostname', () => {
+      expect(hostnameFromApiUrl('https://ghes.example.com/api/v3')).toBe(
+        'ghes.example.com',
+      );
+    });
+
+    it('should return IP address', () => {
+      expect(hostnameFromApiUrl('https://10.0.0.1/api/v3')).toBe('10.0.0.1');
+    });
+
+    it('should strip api. prefix', () => {
+      expect(hostnameFromApiUrl('https://api.ghes.example.com')).toBe(
+        'ghes.example.com',
+      );
+    });
+  });
+
+  describe('isGitHubDotCom', () => {
+    it('should return true for api.github.com', () => {
+      expect(isGitHubDotCom('https://api.github.com')).toBe(true);
+    });
+
+    it('should return true for github.com', () => {
+      expect(isGitHubDotCom('https://github.com')).toBe(true);
+    });
+
+    it('should return false for GHES URL', () => {
+      expect(isGitHubDotCom('https://ghes.example.com/api/v3')).toBe(false);
+    });
+
+    it('should return false for IP-based URL', () => {
+      expect(isGitHubDotCom('https://10.0.0.1/api/v3')).toBe(false);
+    });
+
+    it('should return false for GHES with api prefix', () => {
+      expect(isGitHubDotCom('https://api.ghes.example.com')).toBe(false);
+    });
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -189,12 +189,9 @@ runs:
       shell: bash
       run: |
         BASE_URL="${{ inputs.base-url }}"
-        # Strip protocol
         HOST="${BASE_URL#https://}"
         HOST="${HOST#http://}"
-        # Remove any trailing path
         HOST="${HOST%%/*}"
-        # For public GitHub, api.github.com -> github.com
         if [[ "$HOST" == api.* ]]; then
           HOST="${HOST#api.}"
         fi
@@ -202,60 +199,25 @@ runs:
         echo "gh_host=${HOST}" >> $GITHUB_OUTPUT
         echo "✓ Resolved GH_HOST: ${HOST}"
 
-    - name: Configure TLS for GHES
+    - name: Configure gh CLI TLS for GHES
       if: ${{ inputs.skip-tls-verification == 'true' }}
       shell: bash
       run: |
         HOST="${{ steps.resolve-host.outputs.gh_host }}"
 
-        # Guard: refuse to disable TLS for public github.com
         if [[ "$HOST" == "github.com" ]]; then
           echo "::error::Refusing to disable TLS verification for public github.com. Remove 'skip-tls-verification' or use a GHES base-url."
           exit 1
         fi
 
-        echo "Configuring TLS bypass for non-github.com host: ${HOST}"
+        echo "Configuring TLS bypass for gh CLI (GHES host: ${HOST})"
 
-        # Disable SSL verification for Node.js (Octokit/actions)
-        echo "NODE_TLS_REJECT_UNAUTHORIZED=0" >> $GITHUB_ENV
+        # Node.js and Git TLS bypass is handled by the preflight command.
+        # This step only configures the gh CLI (Go-based, not affected by Node.js env vars).
+        gh config set -h "${HOST}" skip_tls_verification true 2>/dev/null || \
+          echo "::warning::gh CLI does not support skip_tls_verification. gh API calls to GHES may fail with TLS errors."
 
-        # Suppress Node.js TLS warnings
-        echo "NODE_NO_WARNINGS=1" >> $GITHUB_ENV
-
-        # Disable SSL verification for Git operations scoped to the GHES host
-        git config --global "http.https://${HOST}/.sslVerify" false
-
-        # Disable SSL verification for gh CLI (Go-based, not affected by NODE_TLS)
-        # skip_tls_verification requires gh >= 2.54.0
-        GH_VERSION=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-        echo "  gh CLI version: ${GH_VERSION}"
-        GH_MAJOR=$(echo "$GH_VERSION" | cut -d. -f1)
-        GH_MINOR=$(echo "$GH_VERSION" | cut -d. -f2)
-        if [[ "$GH_MAJOR" -gt 2 ]] || { [[ "$GH_MAJOR" -eq 2 ]] && [[ "$GH_MINOR" -ge 54 ]]; }; then
-          gh config set -h "${HOST}" skip_tls_verification true
-          echo "✓ TLS bypass configured via gh config for ${HOST}"
-        else
-          echo "⚠️  gh CLI ${GH_VERSION} does not support skip_tls_verification (requires >= 2.54.0)"
-          echo "  Attempting to upgrade gh CLI..."
-          if command -v apt-get &> /dev/null; then
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt-get update -qq && sudo apt-get install -qq -y gh > /dev/null 2>&1
-          elif command -v brew &> /dev/null; then
-            brew upgrade gh 2>/dev/null || brew install gh 2>/dev/null
-          fi
-          NEW_VERSION=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          echo "  gh CLI version after upgrade: ${NEW_VERSION}"
-          NEW_MAJOR=$(echo "$NEW_VERSION" | cut -d. -f1)
-          NEW_MINOR=$(echo "$NEW_VERSION" | cut -d. -f2)
-          if [[ "$NEW_MAJOR" -gt 2 ]] || { [[ "$NEW_MAJOR" -eq 2 ]] && [[ "$NEW_MINOR" -ge 54 ]]; }; then
-            gh config set -h "${HOST}" skip_tls_verification true
-          else
-            echo "::warning::gh CLI ${NEW_VERSION} still does not support skip_tls_verification. gh API calls to GHES may fail with TLS errors. Node.js, Git, and curl TLS bypass are still active."
-          fi
-        fi
-
-        echo "✓ TLS bypass configured for ${HOST}"
+        echo "✓ gh CLI TLS bypass configured for ${HOST}"
 
     - name: Setup Paths
       id: setup-paths
@@ -291,105 +253,6 @@ runs:
         github-api-url: ${{ inputs.base-url }}
         repositories: ${{ inputs.repository }}
 
-    - name: Validate Repository Exists
-      if: ${{ inputs.type == 'repository' }}
-      shell: bash
-      env:
-        GH_TOKEN: ${{ steps.app-install.outputs.token || inputs.access-token || inputs.github-token }}
-        GH_HOST: ${{ steps.resolve-host.outputs.gh_host }}
-        BASE_URL: ${{ inputs.base-url }}
-        TOKEN_SOURCE: ${{ steps.app-install.outputs.token != '' && 'GitHub App' || (inputs.access-token != '' && 'Access Token' || 'github-token (fallback)') }}
-        SKIP_TLS: ${{ inputs.skip-tls-verification }}
-      run: |
-        echo "Validating repository: ${{ inputs.organization }}/${{ inputs.repository }}"
-        echo "  GH_HOST: ${GH_HOST}"
-        echo "  Base URL: ${BASE_URL}"
-        echo "  Token length: ${#GH_TOKEN}"
-        echo "  Token source: ${TOKEN_SOURCE}"
-        echo "  Skip TLS: ${SKIP_TLS}"
-
-        CURL_OPTS=(-s --max-time 15)
-        if [[ "${SKIP_TLS}" == "true" ]]; then
-          CURL_OPTS+=(-k)
-        fi
-
-        HTTP_CODE=$(curl "${CURL_OPTS[@]}" \
-          -H "Authorization: token ${GH_TOKEN}" \
-          -H "Accept: application/vnd.github+json" \
-          -o /tmp/repo-validate.json \
-          -w "%{http_code}" \
-          "${BASE_URL}/repos/${{ inputs.organization }}/${{ inputs.repository }}") || true
-
-        if [[ "$HTTP_CODE" == "200" ]]; then
-          FULL_NAME=$(jq -r '.full_name' /tmp/repo-validate.json 2>/dev/null)
-          echo "✓ Repository exists and is accessible: ${FULL_NAME}"
-          exit 0
-        fi
-
-        echo "::error::Failed to validate repository: ${{ inputs.organization }}/${{ inputs.repository }}"
-        echo "  HTTP status: ${HTTP_CODE}"
-        echo "  Response:"
-        cat /tmp/repo-validate.json 2>/dev/null || echo "  (no response body)"
-        exit 1
-
-    - name: Validate App Install Stats Auth
-      if: ${{ inputs.type == 'app-install-stats' }}
-      shell: bash
-      env:
-        ACCESS_TOKEN: ${{ inputs.access-token }}
-        APP_ID: ${{ inputs.github-app-id }}
-        APP_KEY: ${{ inputs.github-app-private-key }}
-      run: |
-        if [[ -z "${ACCESS_TOKEN}" ]]; then
-          echo "::error::app-install-stats requires a Personal Access Token (access-token). GitHub App tokens cannot view other apps' installations."
-          exit 1
-        fi
-        if [[ -n "${APP_ID}" ]] || [[ -n "${APP_KEY}" ]]; then
-          echo "::warning::GitHub App credentials are ignored for app-install-stats. Only the access-token (PAT) will be used."
-        fi
-        echo "✓ App install stats authentication validated"
-
-    - name: Validate Organization Exists
-      if: ${{ inputs.type == 'organization' || inputs.type == 'project-stats' || inputs.type == 'app-install-stats' || inputs.type == 'package-stats' || inputs.type == 'codespace-stats' || inputs.type == 'migration-audit' }}
-      shell: bash
-      env:
-        GH_TOKEN: ${{ steps.app-install.outputs.token || inputs.access-token || inputs.github-token }}
-        GH_HOST: ${{ steps.resolve-host.outputs.gh_host }}
-        BASE_URL: ${{ inputs.base-url }}
-        TOKEN_SOURCE: ${{ steps.app-install.outputs.token != '' && 'GitHub App' || (inputs.access-token != '' && 'Access Token' || 'github-token (fallback)') }}
-        SKIP_TLS: ${{ inputs.skip-tls-verification }}
-      run: |
-        echo "Validating organization: ${{ inputs.organization }}"
-        echo "  GH_HOST: ${GH_HOST}"
-        echo "  Base URL: ${BASE_URL}"
-        echo "  Token length: ${#GH_TOKEN}"
-        echo "  Token source: ${TOKEN_SOURCE}"
-        echo "  Skip TLS: ${SKIP_TLS}"
-
-        CURL_OPTS=(-s --max-time 15)
-        if [[ "${SKIP_TLS}" == "true" ]]; then
-          CURL_OPTS+=(-k)
-        fi
-
-        HTTP_CODE=$(curl "${CURL_OPTS[@]}" \
-          -H "Authorization: token ${GH_TOKEN}" \
-          -H "Accept: application/vnd.github+json" \
-          -o /tmp/org-validate.json \
-          -w "%{http_code}" \
-          "${BASE_URL}/orgs/${{ inputs.organization }}") || true
-
-        if [[ "$HTTP_CODE" == "200" ]]; then
-          LOGIN=$(jq -r '.login' /tmp/org-validate.json 2>/dev/null)
-          echo "✓ Organization exists and is accessible: ${LOGIN}"
-          exit 0
-        fi
-
-        echo "::error::Failed to validate organization: ${{ inputs.organization }}"
-        echo "  HTTP status: ${HTTP_CODE}"
-        echo "  Response:"
-        cat /tmp/org-validate.json 2>/dev/null || echo "  (no response body)"
-        exit 1
-
     - name: Setup Node.js
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 #v6.2.0
       with:
@@ -410,6 +273,47 @@ runs:
         gh migration-audit --version
 
         echo "✓ Dependencies installed successfully"
+
+    - name: Run Preflight Checks
+      if: ${{ inputs.type != 'combine' }}
+      shell: bash
+      env:
+        ACCESS_TOKEN: ${{ steps.app-install.outputs.token || inputs.access-token || inputs.github-token }}
+      run: |
+        PREFLIGHT_ARGS=(
+          --base-url "${{ inputs.base-url }}"
+          --type "${{ inputs.type }}"
+          --org-name "${{ inputs.organization }}"
+          --access-token "${ACCESS_TOKEN}"
+        )
+
+        if [[ "${{ inputs.skip-tls-verification }}" == "true" ]]; then
+          PREFLIGHT_ARGS+=(--skip-tls-verification)
+        fi
+
+        REPOSITORY="${{ inputs.repository }}"
+        if [[ -n "${REPOSITORY}" ]]; then
+          PREFLIGHT_ARGS+=(--repository "${REPOSITORY}")
+        fi
+
+        APP_ID="${{ inputs.github-app-id }}"
+        if [[ -n "${APP_ID}" ]]; then
+          PREFLIGHT_ARGS+=(--app-id "${APP_ID}")
+        fi
+
+        PRIVATE_KEY="${{ inputs.github-app-private-key }}"
+        if [[ -n "${PRIVATE_KEY}" ]]; then
+          PREFLIGHT_ARGS+=(--private-key "${PRIVATE_KEY}")
+        fi
+
+        INSTALL_ID="${{ steps.app-install.outputs.installation-id }}"
+        if [[ -n "${INSTALL_ID}" ]]; then
+          PREFLIGHT_ARGS+=(--app-installation-id "${INSTALL_ID}")
+        fi
+
+        gh repo-stats-plus preflight "${PREFLIGHT_ARGS[@]}"
+
+        echo "✓ Preflight checks completed"
 
     - name: Resolve Resume Mode
       id: resolve-resume

--- a/action.yml
+++ b/action.yml
@@ -210,14 +210,25 @@ runs:
           exit 1
         fi
 
-        echo "Configuring TLS bypass for gh CLI (GHES host: ${HOST})"
+        echo "Configuring TLS bypass for GHES host: ${HOST}"
 
-        # Node.js and Git TLS bypass is handled by the preflight command.
-        # This step only configures the gh CLI (Go-based, not affected by Node.js env vars).
-        gh config set -h "${HOST}" skip_tls_verification true 2>/dev/null || \
+        # Persist TLS bypass for all subsequent composite action steps.
+        # process.env changes in Node.js do not carry over between steps,
+        # so we must write to $GITHUB_ENV for downstream commands.
+        echo "NODE_TLS_REJECT_UNAUTHORIZED=0" >> "$GITHUB_ENV"
+        echo "NODE_NO_WARNINGS=1" >> "$GITHUB_ENV"
+
+        # Scope Git TLS bypass to the GHES host (not globally)
+        git config --global "http.https://${HOST}/.sslVerify" false
+
+        # Configure the gh CLI (Go-based, not affected by Node.js env vars)
+        if gh config set -h "${HOST}" skip_tls_verification true 2>/dev/null; then
+          echo "✓ gh CLI TLS bypass configured for ${HOST}"
+        else
           echo "::warning::gh CLI does not support skip_tls_verification. gh API calls to GHES may fail with TLS errors."
+        fi
 
-        echo "✓ gh CLI TLS bypass configured for ${HOST}"
+        echo "✓ TLS bypass configured for ${HOST}"
 
     - name: Setup Paths
       id: setup-paths
@@ -278,7 +289,7 @@ runs:
       if: ${{ inputs.type != 'combine' }}
       shell: bash
       env:
-        ACCESS_TOKEN: ${{ steps.app-install.outputs.token || inputs.access-token || inputs.github-token }}
+        ACCESS_TOKEN: ${{ inputs.type == 'app-install-stats' && inputs.access-token || steps.app-install.outputs.token || inputs.access-token || inputs.github-token }}
       run: |
         PREFLIGHT_ARGS=(
           --base-url "${{ inputs.base-url }}"

--- a/src/commands/preflight-command.ts
+++ b/src/commands/preflight-command.ts
@@ -1,0 +1,217 @@
+import * as commander from 'commander';
+import { parseBooleanOption } from '../utils.js';
+import { createLogger } from '../logger.js';
+import { createAuthConfig } from '../auth.js';
+import { createOctokit } from '../octokit.js';
+import { OctokitClient, DEFAULT_API_VERSION } from '../service.js';
+import { configureSslBypass } from '../tls.js';
+import { hostnameFromApiUrl, isGitHubDotCom } from '../url-utils.js';
+import VERSION from '../version.js';
+
+const { Option } = commander;
+
+/** Stats-gathering types that require organization validation. */
+const ORG_TYPES = new Set([
+  'organization',
+  'project-stats',
+  'app-install-stats',
+  'package-stats',
+  'codespace-stats',
+  'migration-audit',
+]);
+
+/** Valid values for the --type option. */
+const VALID_TYPES = [
+  'repository',
+  'organization',
+  'project-stats',
+  'app-install-stats',
+  'package-stats',
+  'codespace-stats',
+  'migration-audit',
+  'combine',
+];
+
+interface PreflightOptions {
+  baseUrl: string;
+  skipTlsVerification?: boolean;
+  orgName?: string;
+  repository?: string;
+  type: string;
+  accessToken?: string;
+  appId?: string;
+  privateKey?: string;
+  appInstallationId?: string;
+  verbose?: boolean;
+}
+
+function validate(opts: PreflightOptions): void {
+  if (!VALID_TYPES.includes(opts.type)) {
+    throw new Error(
+      `Invalid type '${opts.type}'. Must be one of: ${VALID_TYPES.join(', ')}`,
+    );
+  }
+
+  if (opts.type === 'repository' && !opts.repository) {
+    throw new Error(
+      "A repository name is required when type is 'repository'. " +
+        'Pass --repository <name>.',
+    );
+  }
+
+  if (ORG_TYPES.has(opts.type) && !opts.orgName) {
+    throw new Error(
+      `An organization name is required when type is '${opts.type}'. ` +
+        'Pass --org-name <org>.',
+    );
+  }
+
+  if (opts.type === 'app-install-stats') {
+    if (!opts.accessToken) {
+      throw new Error(
+        'app-install-stats requires a Personal Access Token (--access-token). ' +
+          "GitHub App tokens cannot view other apps' installations.",
+      );
+    }
+    if (opts.appId) {
+      console.warn(
+        'Warning: GitHub App credentials are ignored for app-install-stats. ' +
+          'Only the access-token (PAT) will be used.',
+      );
+    }
+  }
+}
+
+export async function runPreflight(opts: PreflightOptions): Promise<void> {
+  const logger = await createLogger(opts.verbose ?? false, 'preflight.log');
+
+  // 1. Resolve hostname
+  const ghHost = hostnameFromApiUrl(opts.baseUrl);
+  const isPublicGitHub = isGitHubDotCom(opts.baseUrl);
+  logger.info(`Resolved GH_HOST: ${ghHost}`);
+
+  // 2. Configure TLS bypass if requested
+  const sslVerifyDisabled = opts.skipTlsVerification === true;
+  if (sslVerifyDisabled) {
+    configureSslBypass(opts.baseUrl, logger);
+  }
+
+  // 3. Determine if we need to validate with an API call
+  const needsRepoValidation = opts.type === 'repository';
+  const needsOrgValidation = ORG_TYPES.has(opts.type);
+
+  if (needsRepoValidation || needsOrgValidation) {
+    logger.info('Creating authenticated client for validation...');
+    const authConfig = createAuthConfig({
+      accessToken: opts.accessToken,
+      appId: opts.appId,
+      privateKey: opts.privateKey,
+      appInstallationId: opts.appInstallationId,
+      logger,
+    });
+
+    const octokit = createOctokit(authConfig, opts.baseUrl, undefined, logger);
+    const client = new OctokitClient(octokit, DEFAULT_API_VERSION);
+
+    // 4. Validate repository exists
+    if (needsRepoValidation && opts.orgName && opts.repository) {
+      logger.info(`Validating repository: ${opts.orgName}/${opts.repository}`);
+      const { fullName } = await client.validateRepository(
+        opts.orgName,
+        opts.repository,
+      );
+      logger.info(`Repository exists and is accessible: ${fullName}`);
+    }
+
+    // 5. Validate organization exists
+    if (needsOrgValidation && opts.orgName) {
+      logger.info(`Validating organization: ${opts.orgName}`);
+      const { login } = await client.validateOrganization(opts.orgName);
+      logger.info(`Organization exists and is accessible: ${login}`);
+    }
+  }
+
+  // 6. Output key=value pairs for action.yml consumption
+  console.log(`gh_host=${ghHost}`);
+  console.log(`ssl_verify_disabled=${sslVerifyDisabled}`);
+  console.log(`is_github_com=${isPublicGitHub}`);
+}
+
+export function createPreflightCommand(): commander.Command {
+  const command = new commander.Command();
+
+  command
+    .name('preflight')
+    .description(
+      'Runs pre-flight checks: resolves host, configures TLS, and validates API access',
+    )
+    .version(VERSION)
+    .addOption(
+      new Option('-u, --base-url <url>', 'GitHub API base URL')
+        .env('BASE_URL')
+        .default('https://api.github.com'),
+    )
+    .addOption(
+      new Option(
+        '--skip-tls-verification [value]',
+        'Skip TLS certificate verification (for GHES with self-signed certs)',
+      )
+        .env('SKIP_TLS_VERIFICATION')
+        .default(false)
+        .argParser(parseBooleanOption),
+    )
+    .addOption(
+      new Option(
+        '-o, --org-name <org>',
+        'Organization or owner name to validate',
+      ).env('ORG_NAME'),
+    )
+    .addOption(
+      new Option(
+        '-r, --repository <repo>',
+        'Repository name to validate (when type is repository)',
+      ).env('REPOSITORY'),
+    )
+    .addOption(
+      new Option(
+        '--type <type>',
+        `Type of stats gathering (${VALID_TYPES.join(', ')})`,
+      )
+        .env('STATS_TYPE')
+        .default('repository'),
+    )
+    .addOption(
+      new Option('-t, --access-token <token>', 'GitHub access token').env(
+        'ACCESS_TOKEN',
+      ),
+    )
+    .addOption(new Option('--app-id <id>', 'GitHub App ID').env('APP_ID'))
+    .addOption(
+      new Option('--private-key <key>', 'GitHub App private key').env(
+        'PRIVATE_KEY',
+      ),
+    )
+    .addOption(
+      new Option(
+        '--app-installation-id <id>',
+        'GitHub App installation ID',
+      ).env('APP_INSTALLATION_ID'),
+    )
+    .addOption(
+      new Option('-v, --verbose', 'Enable verbose logging').env('VERBOSE'),
+    )
+    .action(async (options: PreflightOptions) => {
+      console.log('Version:', VERSION);
+
+      console.log('Validating preflight options...');
+      validate(options);
+
+      console.log('Running preflight checks...');
+      await runPreflight(options);
+      console.log('Preflight checks completed.');
+    });
+
+  return command;
+}
+
+export default createPreflightCommand();

--- a/src/commands/preflight-command.ts
+++ b/src/commands/preflight-command.ts
@@ -52,11 +52,19 @@ function validate(opts: PreflightOptions): void {
     );
   }
 
-  if (opts.type === 'repository' && !opts.repository) {
-    throw new Error(
-      "A repository name is required when type is 'repository'. " +
-        'Pass --repository <name>.',
-    );
+  if (opts.type === 'repository') {
+    if (!opts.repository) {
+      throw new Error(
+        "A repository name is required when type is 'repository'. " +
+          'Pass --repository <name>.',
+      );
+    }
+    if (!opts.orgName) {
+      throw new Error(
+        "An organization name is required when type is 'repository'. " +
+          'Pass --org-name <org>.',
+      );
+    }
   }
 
   if (ORG_TYPES.has(opts.type) && !opts.orgName) {
@@ -83,6 +91,8 @@ function validate(opts: PreflightOptions): void {
 }
 
 export async function runPreflight(opts: PreflightOptions): Promise<void> {
+  validate(opts);
+
   const logger = await createLogger(opts.verbose ?? false, 'preflight.log');
 
   // 1. Resolve hostname
@@ -202,9 +212,6 @@ export function createPreflightCommand(): commander.Command {
     )
     .action(async (options: PreflightOptions) => {
       console.log('Version:', VERSION);
-
-      console.log('Validating preflight options...');
-      validate(options);
 
       console.log('Running preflight checks...');
       await runPreflight(options);

--- a/src/commands/preflight-command.ts
+++ b/src/commands/preflight-command.ts
@@ -4,7 +4,7 @@ import { createLogger } from '../logger.js';
 import { createAuthConfig } from '../auth.js';
 import { createOctokit } from '../octokit.js';
 import { OctokitClient, DEFAULT_API_VERSION } from '../service.js';
-import { configureSslBypass } from '../tls.js';
+import { resolveTlsDispatcher } from '../tls.js';
 import { hostnameFromApiUrl, isGitHubDotCom } from '../url-utils.js';
 import VERSION from '../version.js';
 
@@ -35,6 +35,7 @@ const VALID_TYPES = [
 interface PreflightOptions {
   baseUrl: string;
   skipTlsVerification?: boolean;
+  caCertPath?: string;
   orgName?: string;
   repository?: string;
   type: string;
@@ -100,11 +101,16 @@ export async function runPreflight(opts: PreflightOptions): Promise<void> {
   const isPublicGitHub = isGitHubDotCom(opts.baseUrl);
   logger.info(`Resolved GH_HOST: ${ghHost}`);
 
-  // 2. Configure TLS bypass if requested
+  // 2. Resolve TLS: prefer CA cert over global SSL bypass.
+  //    resolveTlsDispatcher checks caCertPath arg first, then GHES_CA_CERT_PATH env var,
+  //    then falls back to configureSslBypass() when skipTlsVerification is true.
   const sslVerifyDisabled = opts.skipTlsVerification === true;
-  if (sslVerifyDisabled) {
-    configureSslBypass(opts.baseUrl, logger);
-  }
+  const caCertDispatcher = resolveTlsDispatcher(
+    opts.baseUrl,
+    sslVerifyDisabled,
+    logger,
+    opts.caCertPath,
+  );
 
   // 3. Determine if we need to validate with an API call
   const needsRepoValidation = opts.type === 'repository';
@@ -120,7 +126,14 @@ export async function runPreflight(opts: PreflightOptions): Promise<void> {
       logger,
     });
 
-    const octokit = createOctokit(authConfig, opts.baseUrl, undefined, logger);
+    const octokit = createOctokit(
+      authConfig,
+      opts.baseUrl,
+      undefined,
+      logger,
+      undefined,
+      caCertDispatcher,
+    );
     const client = new OctokitClient(octokit, DEFAULT_API_VERSION);
 
     // 4. Validate repository exists
@@ -143,7 +156,8 @@ export async function runPreflight(opts: PreflightOptions): Promise<void> {
 
   // 6. Output key=value pairs for action.yml consumption
   console.log(`gh_host=${ghHost}`);
-  console.log(`ssl_verify_disabled=${sslVerifyDisabled}`);
+  console.log(`ssl_verify_disabled=${sslVerifyDisabled && !caCertDispatcher}`);
+  console.log(`ca_cert_used=${caCertDispatcher !== undefined}`);
   console.log(`is_github_com=${isPublicGitHub}`);
 }
 
@@ -164,11 +178,20 @@ export function createPreflightCommand(): commander.Command {
     .addOption(
       new Option(
         '--skip-tls-verification [value]',
-        'Skip TLS certificate verification (for GHES with self-signed certs)',
+        'Skip TLS certificate verification (for GHES with self-signed certs). ' +
+          'Prefer --ca-cert-path for proper verification instead of disabling it globally.',
       )
         .env('SKIP_TLS_VERIFICATION')
         .default(false)
         .argParser(parseBooleanOption),
+    )
+    .addOption(
+      new Option(
+        '--ca-cert-path <path>',
+        'Path to a PEM CA certificate for TLS verification against GHES. ' +
+          'When set, uses proper TLS instead of disabling verification globally. ' +
+          'Also reads GHES_CA_CERT_PATH environment variable.',
+      ).env('GHES_CA_CERT_PATH'),
     )
     .addOption(
       new Option(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import codespaceStatsCommand from './commands/codespace-stats-command.js';
 import combineStatsCommand from './commands/combine-stats-command.js';
 import postProcessCommand from './commands/post-process-command.js';
 import rowsToColumnsCommand from './commands/rows-to-columns-command.js';
+import preflightCommand from './commands/preflight-command.js';
 
 const program = new commander.Command();
 
@@ -29,6 +30,7 @@ program
   .addCommand(codespaceStatsCommand)
   .addCommand(combineStatsCommand)
   .addCommand(postProcessCommand)
-  .addCommand(rowsToColumnsCommand);
+  .addCommand(rowsToColumnsCommand)
+  .addCommand(preflightCommand);
 
 program.parse(process.argv);

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -1,6 +1,7 @@
 import {
   fetch as undiciFetch,
   ProxyAgent,
+  Agent as UndiciAgent,
   RequestInfo as undiciRequestInfo,
   RequestInit as undiciRequestInit,
 } from 'undici';
@@ -23,11 +24,16 @@ export const createOctokit = (
   proxyUrl: string | undefined,
   logger: Logger,
   fetch?: any,
+  caCertDispatcher?: UndiciAgent,
 ): Octokit => {
   const customFetch = (url: undiciRequestInfo, options: undiciRequestInit) => {
+    // CA cert dispatcher takes precedence over proxy for GHES TLS verification.
+    // Proxy support alongside a CA cert is not currently handled.
+    const dispatcher =
+      caCertDispatcher ?? (proxyUrl ? new ProxyAgent(proxyUrl) : undefined);
     return undiciFetch(url, {
       ...options,
-      dispatcher: proxyUrl ? new ProxyAgent(proxyUrl) : undefined,
+      dispatcher,
     });
   };
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -62,6 +62,58 @@ export class OctokitClient {
     return appToken.token;
   }
 
+  async validateRepository(
+    owner: string,
+    repo: string,
+  ): Promise<{ fullName: string }> {
+    try {
+      const response = await this.octokit.rest.repos.get({
+        owner,
+        repo,
+        headers: this.octokit_headers,
+      });
+      return { fullName: response.data.full_name };
+    } catch (error: unknown) {
+      const status = (error as { status?: number }).status;
+      if (status === 404) {
+        throw new Error(
+          `Repository not found: ${owner}/${repo}. ` +
+            'Verify the repository exists and the token has access.',
+          { cause: error },
+        );
+      }
+      throw new Error(
+        `Failed to validate repository ${owner}/${repo}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  async validateOrganization(org: string): Promise<{ login: string }> {
+    try {
+      const response = await this.octokit.rest.orgs.get({
+        org,
+        headers: this.octokit_headers,
+      });
+      return { login: response.data.login };
+    } catch (error: unknown) {
+      const status = (error as { status?: number }).status;
+      if (status === 404) {
+        throw new Error(
+          `Organization not found: ${org}. ` +
+            'Verify the organization exists and the token has access.',
+          { cause: error },
+        );
+      }
+      throw new Error(
+        `Failed to validate organization ${org}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
   async *listReposForOrg(
     org: string,
     per_page: number,

--- a/src/tls.ts
+++ b/src/tls.ts
@@ -29,10 +29,12 @@ export function configureSslBypass(baseUrl: string, logger: Logger): void {
   logger.info('Disabling SSL verification for GHES connection');
 
   // Disable SSL verification for Node.js (Octokit, fetch, etc.)
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  // This is intentional: users explicitly opt in via --skip-tls-verification,
+  // and the github.com guard above prevents misuse against public GitHub.
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // lgtm[js/disabling-certificate-validation]
 
   // Disable SSL verification for Git operations
-  process.env.GIT_SSL_NO_VERIFY = '1';
+  process.env.GIT_SSL_NO_VERIFY = '1'; // lgtm[js/disabling-certificate-validation]
 
   // Suppress Node.js TLS deprecation warnings in downstream processes
   process.env.NODE_NO_WARNINGS = '1';

--- a/src/tls.ts
+++ b/src/tls.ts
@@ -1,0 +1,41 @@
+import { Logger } from './types.js';
+import { isGitHubDotCom } from './url-utils.js';
+
+export class TlsBypassError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TlsBypassError';
+  }
+}
+
+/**
+ * Configures SSL/TLS bypass for GHES connections with self-signed certificates.
+ * Sets environment variables that affect Node.js (Octokit), Git, and downstream processes.
+ *
+ * Must be called **before** creating any Octokit clients or making HTTPS requests.
+ *
+ * @param baseUrl - The GitHub API base URL (used to guard against disabling TLS for github.com)
+ * @param logger - Logger instance for diagnostic output
+ * @throws {TlsBypassError} If the base URL resolves to github.com
+ */
+export function configureSslBypass(baseUrl: string, logger: Logger): void {
+  if (isGitHubDotCom(baseUrl)) {
+    throw new TlsBypassError(
+      'Refusing to disable TLS verification for public github.com. ' +
+        "Remove '--skip-tls-verification' or use a GHES base-url.",
+    );
+  }
+
+  logger.info('Disabling SSL verification for GHES connection');
+
+  // Disable SSL verification for Node.js (Octokit, fetch, etc.)
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+  // Disable SSL verification for Git operations
+  process.env.GIT_SSL_NO_VERIFY = '1';
+
+  // Suppress Node.js TLS deprecation warnings in downstream processes
+  process.env.NODE_NO_WARNINGS = '1';
+
+  logger.info('SSL bypass configured for Node.js and Git');
+}

--- a/src/tls.ts
+++ b/src/tls.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+import { Agent as UndiciAgent } from 'undici';
 import { Logger } from './types.js';
 import { isGitHubDotCom } from './url-utils.js';
 
@@ -14,6 +16,9 @@ export class TlsBypassError extends Error {
  *
  * Must be called **before** creating any Octokit clients or making HTTPS requests.
  *
+ * Prefer {@link createCaCertDispatcher} when a CA certificate is available — it verifies
+ * TLS against a known CA instead of disabling verification globally.
+ *
  * @param baseUrl - The GitHub API base URL (used to guard against disabling TLS for github.com)
  * @param logger - Logger instance for diagnostic output
  * @throws {TlsBypassError} If the base URL resolves to github.com
@@ -27,6 +32,10 @@ export function configureSslBypass(baseUrl: string, logger: Logger): void {
   }
 
   logger.info('Disabling SSL verification for GHES connection');
+  logger.warn(
+    'SSL bypass is active (NODE_TLS_REJECT_UNAUTHORIZED=0). ' +
+      'Set GHES_CA_CERT_PATH to a PEM certificate file for proper TLS verification.',
+  );
 
   // Disable SSL verification for Node.js (Octokit, fetch, etc.)
   // This is intentional: users explicitly opt in via --skip-tls-verification,
@@ -37,4 +46,72 @@ export function configureSslBypass(baseUrl: string, logger: Logger): void {
   process.env.NODE_NO_WARNINGS = '1';
 
   logger.info('SSL bypass configured for Node.js');
+}
+
+/**
+ * Creates an undici Agent configured with a CA certificate for TLS verification
+ * against GHES instances that use a private or self-signed CA.
+ *
+ * This is the **preferred** alternative to {@link configureSslBypass}: it verifies
+ * TLS against a known CA rather than disabling all certificate validation globally.
+ * The returned Agent is passed as the `dispatcher` when creating Octokit clients.
+ *
+ * @param caCertPath - Filesystem path to a PEM-encoded CA certificate
+ * @param logger - Logger instance for diagnostic output
+ * @returns A configured undici Agent, or `undefined` if the cert could not be read
+ */
+export function createCaCertDispatcher(
+  caCertPath: string,
+  logger: Logger,
+): UndiciAgent | undefined {
+  try {
+    const ca = fs.readFileSync(caCertPath, 'utf8');
+    logger.info(`Using CA certificate for TLS verification`);
+    return new UndiciAgent({ connect: { ca } });
+  } catch (err) {
+    logger.warn(
+      `Failed to read CA certificate from path '${caCertPath}': ${(err as Error).message}. ` +
+        'Falling back to SSL bypass.',
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Resolves the TLS dispatcher for a GHES connection, preferring CA cert-based
+ * verification over a global SSL bypass.
+ *
+ * Resolution order:
+ * 1. Explicit `caCertPath` argument
+ * 2. `GHES_CA_CERT_PATH` environment variable
+ * 3. Global SSL bypass via `configureSslBypass()` (when `skipTlsVerification` is true)
+ *
+ * Returns an undici Agent when a cert is successfully loaded (use as Octokit
+ * `request.fetch` dispatcher). Returns `undefined` when the SSL bypass path is
+ * taken or when neither cert nor bypass is requested.
+ *
+ * @param baseUrl - The GitHub API base URL (guards against disabling TLS for github.com)
+ * @param skipTlsVerification - Whether the caller explicitly requested SSL bypass
+ * @param logger - Logger instance for diagnostic output
+ * @param caCertPath - Optional explicit path to a PEM CA certificate
+ */
+export function resolveTlsDispatcher(
+  baseUrl: string,
+  skipTlsVerification: boolean,
+  logger: Logger,
+  caCertPath?: string,
+): UndiciAgent | undefined {
+  const certPath = caCertPath ?? process.env['GHES_CA_CERT_PATH'] ?? '';
+
+  if (certPath && !isGitHubDotCom(baseUrl)) {
+    const dispatcher = createCaCertDispatcher(certPath, logger);
+    if (dispatcher) return dispatcher;
+    // cert read failed — fall through to bypass if requested
+  }
+
+  if (skipTlsVerification) {
+    configureSslBypass(baseUrl, logger);
+  }
+
+  return undefined;
 }

--- a/src/tls.ts
+++ b/src/tls.ts
@@ -33,11 +33,8 @@ export function configureSslBypass(baseUrl: string, logger: Logger): void {
   // and the github.com guard above prevents misuse against public GitHub.
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // lgtm[js/disabling-certificate-validation]
 
-  // Disable SSL verification for Git operations
-  process.env.GIT_SSL_NO_VERIFY = '1'; // lgtm[js/disabling-certificate-validation]
-
   // Suppress Node.js TLS deprecation warnings in downstream processes
   process.env.NODE_NO_WARNINGS = '1';
 
-  logger.info('SSL bypass configured for Node.js and Git');
+  logger.info('SSL bypass configured for Node.js');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,9 @@ export interface Arguments {
 
   // GitHub API version
   apiVersion?: string;
+
+  // TLS
+  skipTlsVerification?: boolean;
 }
 
 export type AuthResponse = {

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Converts a GitHub API URL to a base URL.
+ * For example: https://api.github.com -> https://github.com
+ *              https://ghes.example.com/api/v3 -> https://ghes.example.com
+ *
+ * @param apiUrl - The GitHub API URL
+ * @returns The base URL with protocol and host only
+ */
+export function apiUrlToBaseUrl(apiUrl: string): string {
+  const url = new URL(apiUrl);
+  if (url.hostname.startsWith('api.')) {
+    url.hostname = url.hostname.slice(4);
+  }
+  url.pathname = '/';
+  return url.origin;
+}
+
+/**
+ * Extracts the hostname from a GitHub API URL, resolving through the base URL.
+ * For example: https://api.github.com -> github.com
+ *              https://ghes.example.com/api/v3 -> ghes.example.com
+ *
+ * @param apiUrl - The GitHub API URL
+ * @returns The hostname portion of the resolved base URL
+ */
+export function hostnameFromApiUrl(apiUrl: string): string {
+  return new URL(apiUrlToBaseUrl(apiUrl)).hostname;
+}
+
+/**
+ * Checks if the given URL points to public GitHub (github.com).
+ *
+ * @param apiUrl - A GitHub API URL or base URL
+ * @returns true if the URL resolves to github.com
+ */
+export function isGitHubDotCom(apiUrl: string): boolean {
+  return hostnameFromApiUrl(apiUrl) === 'github.com';
+}


### PR DESCRIPTION
## Description

Currently, connecting to GHES instances with self-signed or private CA certificates requires disabling TLS verification globally. This PR adds proper CA certificate-based TLS as a preferred alternative -- the cert is loaded into an undici Agent dispatcher that verifies TLS against a known CA instead of bypassing verification entirely.

**Resolution order** (in resolveTlsDispatcher()):
1. Explicit --ca-cert-path CLI argument
2. GHES_CA_CERT_PATH environment variable
3. Global SSL bypass via configureSslBypass() (when --skip-tls-verification is true)
4. Standard TLS (no special handling)

**Key changes:**
- src/tls.ts -- new createCaCertDispatcher() and resolveTlsDispatcher() functions; warning added to configureSslBypass() recommending CA cert path
- src/octokit.ts -- optional caCertDispatcher parameter on createOctokit(), takes precedence over proxy dispatcher
- src/commands/preflight-command.ts -- uses resolveTlsDispatcher() instead of direct configureSslBypass() call; adds --ca-cert-path option and ca_cert_used output
- Tests updated with comprehensive coverage for new TLS functions and preflight integration

**Known limitation (documented):** The CA cert dispatcher is currently only wired through the preflight command. Propagation to init.ts/main.ts for the stats-gathering commands is a follow-up task.

Related: github-admin/analysis#56

## Checklist

- [ ] Issue linked if existing
- [ ] Add a label to the pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

This builds on the existing configure-ssl branch work. The companion PR in github-admin/analysis (#56) converts the configure-ghes-connection action to TypeScript with authenticated Octokit and CA cert support.