### PR TITLE
feat: auto-lookup GitHub App installation ID when not provided

### DIFF
--- a/__tests__/app-install-stats-main.test.ts
+++ b/__tests__/app-install-stats-main.test.ts
@@ -32,6 +32,10 @@ vi.mock('../src/auth.js', () => ({
     authStrategy: undefined,
     auth: 'test-token',
   }),
+  needsInstallationLookup: vi.fn().mockReturnValue(false),
+  createAppLevelAuthConfig: vi
+    .fn()
+    .mockReturnValue({ authStrategy: vi.fn(), auth: { type: 'app' } }),
 }));
 
 vi.mock('../src/octokit.js', () => ({
@@ -42,6 +46,7 @@ vi.mock('../src/service.js', () => ({
   OctokitClient: vi.fn(),
   DEFAULT_API_VERSION: '2022-11-28',
   VALID_API_VERSIONS: ['2022-11-28', '2026-03-10'],
+  lookupInstallationId: vi.fn().mockResolvedValue(12345),
 }));
 
 vi.mock('../src/state.js', () => ({

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -323,7 +323,6 @@ describe('auth', () => {
 
       expect(result.authStrategy).toBeDefined();
       expect(result.auth).toEqual({
-        type: 'app',
         appId: 12345,
         privateKey: 'test-private-key',
       });
@@ -342,7 +341,6 @@ describe('auth', () => {
       const result = createAppLevelAuthConfig('', 'test-key');
 
       expect(result.auth).toEqual({
-        type: 'app',
         appId: 99999,
         privateKey: 'test-key',
       });

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createAuthConfig } from '../src/auth.js';
+import {
+  createAuthConfig,
+  createAppLevelAuthConfig,
+  needsInstallationLookup,
+} from '../src/auth.js';
 import { createMockLogger } from './test-utils.js';
 import { readFileSync } from 'fs';
 
@@ -284,6 +288,91 @@ describe('auth', () => {
           installationId: 67890,
         });
       });
+    });
+  });
+
+  describe('createAppLevelAuthConfig', () => {
+    it('should create app-level auth config with valid inputs', () => {
+      const result = createAppLevelAuthConfig('12345', 'test-private-key');
+
+      expect(result.authStrategy).toBeDefined();
+      expect(result.auth).toEqual({
+        type: 'app',
+        appId: 12345,
+        privateKey: 'test-private-key',
+      });
+    });
+
+    it('should throw when appId is invalid', () => {
+      expect(() =>
+        createAppLevelAuthConfig('not-a-number', 'test-key'),
+      ).toThrow(
+        'You must specify a GitHub app ID using the --app-id argument or GITHUB_APP_ID environment variable.',
+      );
+    });
+
+    it('should fall back to GITHUB_APP_ID env var', () => {
+      process.env.GITHUB_APP_ID = '99999';
+      const result = createAppLevelAuthConfig('', 'test-key');
+
+      expect(result.auth).toEqual({
+        type: 'app',
+        appId: 99999,
+        privateKey: 'test-key',
+      });
+    });
+  });
+
+  describe('needsInstallationLookup', () => {
+    it('should return true when app credentials present but no installation ID', () => {
+      expect(
+        needsInstallationLookup({
+          appId: '12345',
+          privateKey: 'test-key',
+        }),
+      ).toBe(true);
+    });
+
+    it('should return false when installation ID is provided', () => {
+      expect(
+        needsInstallationLookup({
+          appId: '12345',
+          privateKey: 'test-key',
+          appInstallationId: '67890',
+        }),
+      ).toBe(false);
+    });
+
+    it('should return false when no app credentials', () => {
+      expect(needsInstallationLookup({})).toBe(false);
+    });
+
+    it('should return false when only appId is provided (no private key)', () => {
+      expect(needsInstallationLookup({ appId: '12345' })).toBe(false);
+    });
+
+    it('should return true when using privateKeyFile instead of privateKey', () => {
+      expect(
+        needsInstallationLookup({
+          appId: '12345',
+          privateKeyFile: '/path/to/key.pem',
+        }),
+      ).toBe(true);
+    });
+
+    it('should pick up app credentials from environment variables', () => {
+      process.env.GITHUB_APP_ID = '12345';
+      process.env.GITHUB_APP_PRIVATE_KEY = 'env-key';
+
+      expect(needsInstallationLookup({})).toBe(true);
+    });
+
+    it('should return false when GITHUB_APP_INSTALLATION_ID env var is set', () => {
+      process.env.GITHUB_APP_ID = '12345';
+      process.env.GITHUB_APP_PRIVATE_KEY = 'env-key';
+      process.env.GITHUB_APP_INSTALLATION_ID = '67890';
+
+      expect(needsInstallationLookup({})).toBe(false);
     });
   });
 });

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -198,6 +198,32 @@ describe('auth', () => {
         );
       });
 
+      it('should reject app ID with trailing non-numeric characters like "123abc"', () => {
+        expect(() =>
+          createAuthConfig({
+            appId: '123abc',
+            privateKey: 'test-key',
+            appInstallationId: '67890',
+            logger: mockLogger,
+          }),
+        ).toThrow(
+          'You must specify a GitHub app ID using the --app-id argument or GITHUB_APP_ID environment variable.',
+        );
+      });
+
+      it('should reject installation ID with trailing non-numeric characters like "123abc"', () => {
+        expect(() =>
+          createAuthConfig({
+            appId: '12345',
+            privateKey: 'test-key',
+            appInstallationId: '123abc',
+            logger: mockLogger,
+          }),
+        ).toThrow(
+          'You must specify a GitHub app installation ID using the --app-installation-id argument or GITHUB_APP_INSTALLATION_ID environment variable.',
+        );
+      });
+
       it('should throw error for missing private key', () => {
         // Act & Assert
         expect(() =>

--- a/__tests__/check-for-missing-repos.test.ts
+++ b/__tests__/check-for-missing-repos.test.ts
@@ -13,6 +13,10 @@ vi.mock('../src/csv.js', () => ({
 vi.mock('../src/logger.js');
 vi.mock('../src/auth.js', () => ({
   createAuthConfig: vi.fn(() => ({ type: 'token', token: 'test-token' })),
+  needsInstallationLookup: vi.fn().mockReturnValue(false),
+  createAppLevelAuthConfig: vi
+    .fn()
+    .mockReturnValue({ authStrategy: vi.fn(), auth: { type: 'app' } }),
 }));
 vi.mock('../src/octokit.js');
 vi.mock('../src/service.js');

--- a/__tests__/multi-org.test.ts
+++ b/__tests__/multi-org.test.ts
@@ -38,6 +38,10 @@ vi.mock('../src/logger.js', () => ({
 // Mock auth
 vi.mock('../src/auth.js', () => ({
   createAuthConfig: vi.fn().mockReturnValue({ token: 'mock-token' }),
+  needsInstallationLookup: vi.fn().mockReturnValue(false),
+  createAppLevelAuthConfig: vi
+    .fn()
+    .mockReturnValue({ authStrategy: vi.fn(), auth: { type: 'app' } }),
 }));
 
 // Mock octokit
@@ -88,6 +92,7 @@ vi.mock('../src/service.js', () => ({
   }),
   DEFAULT_API_VERSION: '2022-11-28',
   VALID_API_VERSIONS: ['2022-11-28', '2026-03-10'],
+  lookupInstallationId: vi.fn().mockResolvedValue(12345),
 }));
 
 // Mock utils

--- a/__tests__/project-stats-main.test.ts
+++ b/__tests__/project-stats-main.test.ts
@@ -32,6 +32,10 @@ vi.mock('../src/auth.js', () => ({
     authStrategy: undefined,
     auth: 'test-token',
   }),
+  needsInstallationLookup: vi.fn().mockReturnValue(false),
+  createAppLevelAuthConfig: vi
+    .fn()
+    .mockReturnValue({ authStrategy: vi.fn(), auth: { type: 'app' } }),
 }));
 
 vi.mock('../src/octokit.js', () => ({
@@ -42,6 +46,7 @@ vi.mock('../src/service.js', () => ({
   OctokitClient: vi.fn(),
   DEFAULT_API_VERSION: '2022-11-28',
   VALID_API_VERSIONS: ['2022-11-28', '2026-03-10'],
+  lookupInstallationId: vi.fn().mockResolvedValue(12345),
 }));
 
 vi.mock('../src/state.js', () => ({

--- a/__tests__/service.test.ts
+++ b/__tests__/service.test.ts
@@ -4,6 +4,8 @@ import {
   OctokitClient,
   DEFAULT_API_VERSION,
   VALID_API_VERSIONS,
+  getAppInstallationId,
+  lookupInstallationId,
 } from '../src/service.js';
 
 // Setup mocks
@@ -657,5 +659,267 @@ describe('OctokitClient', () => {
         }),
       );
     });
+  });
+});
+
+describe('getAppInstallationId', () => {
+  it('should return installation ID when a matching installation is found', async () => {
+    const mockOctokit = {
+      paginate: {
+        iterator: vi.fn().mockReturnValue(
+          (async function* () {
+            yield {
+              data: [
+                { id: 42, app_id: 12345, account: { login: 'my-org' } },
+                { id: 99, app_id: 99999, account: { login: 'other-org' } },
+              ],
+            };
+          })(),
+        ),
+      },
+      rest: {
+        apps: {
+          listInstallations: vi.fn(),
+        },
+      },
+    };
+
+    const result = await getAppInstallationId(
+      mockOctokit as unknown as Octokit,
+      'my-org',
+      12345,
+    );
+
+    expect(result).toBe(42);
+  });
+
+  it('should be case-insensitive when matching org name', async () => {
+    const mockOctokit = {
+      paginate: {
+        iterator: vi.fn().mockReturnValue(
+          (async function* () {
+            yield {
+              data: [{ id: 77, app_id: 123, account: { login: 'MY-ORG' } }],
+            };
+          })(),
+        ),
+      },
+      rest: {
+        apps: {
+          listInstallations: vi.fn(),
+        },
+      },
+    };
+
+    const result = await getAppInstallationId(
+      mockOctokit as unknown as Octokit,
+      'my-org',
+      123,
+    );
+
+    expect(result).toBe(77);
+  });
+
+  it('should throw when installation is not found', async () => {
+    const mockOctokit = {
+      paginate: {
+        iterator: vi.fn().mockReturnValue(
+          (async function* () {
+            yield {
+              data: [{ id: 1, app_id: 999, account: { login: 'other' } }],
+            };
+          })(),
+        ),
+      },
+      rest: {
+        apps: {
+          listInstallations: vi.fn(),
+        },
+      },
+    };
+
+    await expect(
+      getAppInstallationId(mockOctokit as unknown as Octokit, 'my-org', 12345),
+    ).rejects.toThrow(
+      'Installation not found for app ID 12345 in organization my-org',
+    );
+  });
+
+  it('should wrap API errors', async () => {
+    const mockOctokit = {
+      paginate: {
+        iterator: vi.fn().mockReturnValue(
+          (async function* () {
+            yield { data: [] };
+            throw new Error('API rate limit exceeded');
+          })(),
+        ),
+      },
+      rest: {
+        apps: {
+          listInstallations: vi.fn(),
+        },
+      },
+    };
+
+    await expect(
+      getAppInstallationId(mockOctokit as unknown as Octokit, 'my-org', 12345),
+    ).rejects.toThrow(
+      'Failed to get app installation ID: API rate limit exceeded',
+    );
+  });
+
+  it('should search across multiple pages', async () => {
+    const mockOctokit = {
+      paginate: {
+        iterator: vi.fn().mockReturnValue(
+          (async function* () {
+            yield {
+              data: [{ id: 1, app_id: 111, account: { login: 'org-a' } }],
+            };
+            yield {
+              data: [{ id: 55, app_id: 12345, account: { login: 'my-org' } }],
+            };
+          })(),
+        ),
+      },
+      rest: {
+        apps: {
+          listInstallations: vi.fn(),
+        },
+      },
+    };
+
+    const result = await getAppInstallationId(
+      mockOctokit as unknown as Octokit,
+      'my-org',
+      12345,
+    );
+
+    expect(result).toBe(55);
+  });
+});
+
+describe('lookupInstallationId', () => {
+  it('should call getAppInstallationId using a temp client', async () => {
+    const mockTempOctokit = {
+      paginate: {
+        iterator: vi.fn().mockReturnValue(
+          (async function* () {
+            yield {
+              data: [{ id: 88, app_id: 12345, account: { login: 'acme' } }],
+            };
+          })(),
+        ),
+      },
+      rest: { apps: { listInstallations: vi.fn() } },
+    };
+
+    const mockCreateOctokitFn = vi.fn().mockReturnValue(mockTempOctokit);
+
+    vi.mock('../src/auth.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../src/auth.js')>();
+      return {
+        ...actual,
+        createAppLevelAuthConfig: vi.fn().mockReturnValue({
+          authStrategy: vi.fn(),
+          auth: { type: 'app', appId: 12345, privateKey: 'test-key' },
+        }),
+      };
+    });
+
+    const mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const result = await lookupInstallationId({
+      appId: '12345',
+      privateKey: 'test-key',
+      org: 'acme',
+      createOctokitFn: mockCreateOctokitFn,
+      logger: mockLogger,
+    });
+
+    expect(result).toBe(88);
+    expect(mockCreateOctokitFn).toHaveBeenCalledOnce();
+  });
+
+  it('should throw when appId is empty', async () => {
+    const mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await expect(
+      lookupInstallationId({
+        appId: '',
+        privateKey: 'key',
+        org: 'org',
+        createOctokitFn: vi.fn(),
+        logger: mockLogger,
+      }),
+    ).rejects.toThrow('appId is required');
+  });
+
+  it('should throw when privateKey is empty', async () => {
+    const mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await expect(
+      lookupInstallationId({
+        appId: '12345',
+        privateKey: '',
+        org: 'org',
+        createOctokitFn: vi.fn(),
+        logger: mockLogger,
+      }),
+    ).rejects.toThrow('privateKey is required');
+  });
+
+  it('should throw when org is empty', async () => {
+    const mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await expect(
+      lookupInstallationId({
+        appId: '12345',
+        privateKey: 'key',
+        org: '',
+        createOctokitFn: vi.fn(),
+        logger: mockLogger,
+      }),
+    ).rejects.toThrow('org is required');
+  });
+
+  it('should throw when appId is not numeric', async () => {
+    const mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await expect(
+      lookupInstallationId({
+        appId: 'not-a-number',
+        privateKey: 'key',
+        org: 'org',
+        createOctokitFn: vi.fn(),
+        logger: mockLogger,
+      }),
+    ).rejects.toThrow('appId must be a valid numeric string');
   });
 });

--- a/__tests__/service.test.ts
+++ b/__tests__/service.test.ts
@@ -663,23 +663,11 @@ describe('OctokitClient', () => {
 });
 
 describe('getAppInstallationId', () => {
-  it('should return installation ID when a matching installation is found', async () => {
+  it('should return installation ID via direct org lookup', async () => {
     const mockOctokit = {
-      paginate: {
-        iterator: vi.fn().mockReturnValue(
-          (async function* () {
-            yield {
-              data: [
-                { id: 42, app_id: 12345, account: { login: 'my-org' } },
-                { id: 99, app_id: 99999, account: { login: 'other-org' } },
-              ],
-            };
-          })(),
-        ),
-      },
       rest: {
         apps: {
-          listInstallations: vi.fn(),
+          getOrgInstallation: vi.fn().mockResolvedValue({ data: { id: 42 } }),
         },
       },
     };
@@ -687,132 +675,61 @@ describe('getAppInstallationId', () => {
     const result = await getAppInstallationId(
       mockOctokit as unknown as Octokit,
       'my-org',
-      12345,
     );
 
     expect(result).toBe(42);
+    expect(mockOctokit.rest.apps.getOrgInstallation).toHaveBeenCalledWith({
+      org: 'my-org',
+    });
   });
 
-  it('should be case-insensitive when matching org name', async () => {
+  it('should throw a clear error when the installation is not found (404)', async () => {
     const mockOctokit = {
-      paginate: {
-        iterator: vi.fn().mockReturnValue(
-          (async function* () {
-            yield {
-              data: [{ id: 77, app_id: 123, account: { login: 'MY-ORG' } }],
-            };
-          })(),
-        ),
-      },
       rest: {
         apps: {
-          listInstallations: vi.fn(),
-        },
-      },
-    };
-
-    const result = await getAppInstallationId(
-      mockOctokit as unknown as Octokit,
-      'my-org',
-      123,
-    );
-
-    expect(result).toBe(77);
-  });
-
-  it('should throw when installation is not found', async () => {
-    const mockOctokit = {
-      paginate: {
-        iterator: vi.fn().mockReturnValue(
-          (async function* () {
-            yield {
-              data: [{ id: 1, app_id: 999, account: { login: 'other' } }],
-            };
-          })(),
-        ),
-      },
-      rest: {
-        apps: {
-          listInstallations: vi.fn(),
+          getOrgInstallation: vi
+            .fn()
+            .mockRejectedValue(
+              Object.assign(new Error('Not Found'), { status: 404 }),
+            ),
         },
       },
     };
 
     await expect(
-      getAppInstallationId(mockOctokit as unknown as Octokit, 'my-org', 12345),
+      getAppInstallationId(mockOctokit as unknown as Octokit, 'missing-org'),
     ).rejects.toThrow(
-      'Installation not found for app ID 12345 in organization my-org',
+      'Failed to get app installation ID for organization "missing-org": Not Found',
     );
   });
 
-  it('should wrap API errors', async () => {
+  it('should wrap unexpected API errors', async () => {
     const mockOctokit = {
-      paginate: {
-        iterator: vi.fn().mockReturnValue(
-          (async function* () {
-            yield { data: [] };
-            throw new Error('API rate limit exceeded');
-          })(),
-        ),
-      },
       rest: {
         apps: {
-          listInstallations: vi.fn(),
+          getOrgInstallation: vi
+            .fn()
+            .mockRejectedValue(new Error('API rate limit exceeded')),
         },
       },
     };
 
     await expect(
-      getAppInstallationId(mockOctokit as unknown as Octokit, 'my-org', 12345),
+      getAppInstallationId(mockOctokit as unknown as Octokit, 'my-org'),
     ).rejects.toThrow(
-      'Failed to get app installation ID: API rate limit exceeded',
+      'Failed to get app installation ID for organization "my-org": API rate limit exceeded',
     );
-  });
-
-  it('should search across multiple pages', async () => {
-    const mockOctokit = {
-      paginate: {
-        iterator: vi.fn().mockReturnValue(
-          (async function* () {
-            yield {
-              data: [{ id: 1, app_id: 111, account: { login: 'org-a' } }],
-            };
-            yield {
-              data: [{ id: 55, app_id: 12345, account: { login: 'my-org' } }],
-            };
-          })(),
-        ),
-      },
-      rest: {
-        apps: {
-          listInstallations: vi.fn(),
-        },
-      },
-    };
-
-    const result = await getAppInstallationId(
-      mockOctokit as unknown as Octokit,
-      'my-org',
-      12345,
-    );
-
-    expect(result).toBe(55);
   });
 });
 
 describe('lookupInstallationId', () => {
   it('should call getAppInstallationId using a temp client', async () => {
     const mockTempOctokit = {
-      paginate: {
-        iterator: vi.fn().mockReturnValue(
-          (async function* () {
-            yield {
-              data: [{ id: 88, app_id: 12345, account: { login: 'acme' } }],
-            };
-          })(),
-        ),
+      rest: {
+        apps: {
+          getOrgInstallation: vi.fn().mockResolvedValue({ data: { id: 88 } }),
+        },
       },
-      rest: { apps: { listInstallations: vi.fn() } },
     };
 
     const mockCreateOctokitFn = vi.fn().mockReturnValue(mockTempOctokit);

--- a/docs/commands/codespace-stats.md
+++ b/docs/commands/codespace-stats.md
@@ -23,7 +23,7 @@ gh repo-stats-plus codespace-stats [options]
 - `--app-id <id>`: GitHub App ID for authentication
 - `--private-key <key>`: GitHub App private key content
 - `--private-key-file <path>`: Path to GitHub App private key file
-- `--app-installation-id <id>`: GitHub App installation ID
+- `--app-installation-id <id>`: GitHub App installation ID (optional — automatically looked up if omitted)
 
 ### Configuration
 
@@ -86,6 +86,13 @@ gh repo-stats-plus codespace-stats \
 ### With GitHub App Authentication
 
 ```bash
+# Installation ID is auto-looked up when omitted
+gh repo-stats-plus codespace-stats \
+  --org-name my-org \
+  --app-id 12345 \
+  --private-key-file ./key.pem
+
+# Or provide it explicitly to skip the lookup
 gh repo-stats-plus codespace-stats \
   --org-name my-org \
   --app-id 12345 \

--- a/docs/commands/missing-repos.md
+++ b/docs/commands/missing-repos.md
@@ -25,7 +25,7 @@ gh repo-stats-plus missing-repos [options]
 - `--app-id <id>`: GitHub App ID
 - `--private-key <key>`: GitHub App private key
 - `--private-key-file <file>`: Path to GitHub App private key file
-- `--app-installation-id <id>`: GitHub App installation ID
+- `--app-installation-id <id>`: GitHub App installation ID (optional — automatically looked up if omitted)
 
 ### Performance
 
@@ -53,6 +53,14 @@ gh repo-stats-plus missing-repos \
 ### With GitHub App Authentication
 
 ```bash
+# Installation ID is auto-looked up when omitted
+gh repo-stats-plus missing-repos \
+  --org-name github \
+  --file github-repo-stats.csv \
+  --app-id 12345 \
+  --private-key-file /path/to/key.pem
+
+# Or provide it explicitly to skip the lookup
 gh repo-stats-plus missing-repos \
   --org-name github \
   --file github-repo-stats.csv \

--- a/docs/commands/package-stats.md
+++ b/docs/commands/package-stats.md
@@ -25,7 +25,7 @@ gh repo-stats-plus package-stats [options]
 - `--app-id <id>`: GitHub App ID for authentication
 - `--private-key <key>`: GitHub App private key content
 - `--private-key-file <path>`: Path to GitHub App private key file
-- `--app-installation-id <id>`: GitHub App installation ID
+- `--app-installation-id <id>`: GitHub App installation ID (optional — automatically looked up if omitted)
 
 ### Configuration
 
@@ -105,6 +105,13 @@ gh repo-stats-plus package-stats \
 ### With GitHub App Authentication
 
 ```bash
+# Installation ID is auto-looked up when omitted
+gh repo-stats-plus package-stats \
+  --org-name my-org \
+  --app-id 12345 \
+  --private-key-file ./key.pem
+
+# Or provide it explicitly to skip the lookup
 gh repo-stats-plus package-stats \
   --org-name my-org \
   --app-id 12345 \

--- a/docs/commands/project-stats.md
+++ b/docs/commands/project-stats.md
@@ -21,7 +21,7 @@ gh repo-stats-plus project-stats [options]
 - `--app-id <id>`: GitHub App ID
 - `--private-key <key>`: GitHub App private key
 - `--private-key-file <file>`: Path to GitHub App private key file
-- `--app-installation-id <id>`: GitHub App installation ID
+- `--app-installation-id <id>`: GitHub App installation ID (optional — automatically looked up if omitted)
 
 ### Configuration
 
@@ -86,6 +86,13 @@ gh repo-stats-plus project-stats --org-name my-org --access-token ghp_xxxxxxxxxx
 ### With GitHub App
 
 ```bash
+# Installation ID is auto-looked up when omitted
+gh repo-stats-plus project-stats \
+  --org-name my-org \
+  --app-id 12345 \
+  --private-key-file /path/to/key.pem
+
+# Or provide it explicitly to skip the lookup
 gh repo-stats-plus project-stats \
   --org-name my-org \
   --app-id 12345 \

--- a/docs/commands/repo-stats.md
+++ b/docs/commands/repo-stats.md
@@ -24,7 +24,7 @@ gh repo-stats-plus repo-stats [options]
 - `--app-id <id>`: GitHub App ID
 - `--private-key <key>`: GitHub App private key
 - `--private-key-file <file>`: Path to GitHub App private key file
-- `--app-installation-id <id>`: GitHub App installation ID
+- `--app-installation-id <id>`: GitHub App installation ID (optional — automatically looked up if omitted)
 
 ### Performance
 
@@ -73,6 +73,13 @@ gh repo-stats-plus repo-stats --org-name github --access-token ghp_xxxxxxxxxxxx
 ### With GitHub App
 
 ```bash
+# Installation ID is auto-looked up when omitted
+gh repo-stats-plus repo-stats \
+  --org-name github \
+  --app-id 12345 \
+  --private-key-file /path/to/key.pem
+
+# Or provide it explicitly to skip the lookup
 gh repo-stats-plus repo-stats \
   --org-name github \
   --app-id 12345 \

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,7 +75,7 @@ Configure the following environment variables in your `.env` file:
 - `APP_ID`: GitHub App ID (alternative to PAT)
 - `PRIVATE_KEY`: GitHub App private key
 - `PRIVATE_KEY_FILE`: Path to GitHub App private key file
-- `APP_INSTALLATION_ID`: GitHub App installation ID
+- `APP_INSTALLATION_ID`: GitHub App installation ID (optional — automatically looked up if omitted)
 
 ### Performance and Pagination
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,9 +44,10 @@ gh repo-stats-plus repo-stats --org-name my-org --resume-from-last-save
 gh repo-stats-plus repo-stats \
   --org-name my-org \
   --app-id YOUR_APP_ID \
-  --private-key-file key.pem \
-  --app-installation-id INSTALLATION_ID
+  --private-key-file key.pem
 ```
+
+> **Note:** `--app-installation-id` is optional. When omitted, the CLI automatically looks up the installation ID via the GitHub API. You can still provide it explicitly to skip the lookup.
 
 ### Process Missing Repositories
 
@@ -132,7 +133,16 @@ When using GitHub CLI authentication, you can use your personal access token. Th
 
 ### GitHub App Authentication
 
-For GitHub App authentication, you can pass additional parameters:
+For GitHub App authentication, provide your App ID and private key:
+
+```bash
+gh repo-stats-plus repo-stats \
+  --org-name myorg \
+  --app-id 12345 \
+  --private-key-file /path/to/key.pem
+```
+
+The `--app-installation-id` flag is optional. When omitted, the CLI automatically looks up the installation ID for the target organization using the GitHub API. If you already know the installation ID, you can provide it explicitly to skip the lookup:
 
 ```bash
 gh repo-stats-plus repo-stats \

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -23,7 +23,7 @@ const getAuthAppId = (appId?: string): number => {
   return parseInt(authAppId, 10);
 };
 
-const getAuthPrivateKey = (
+export const getAuthPrivateKey = (
   privateKey?: string,
   privateKeyFile?: string,
 ): string => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,7 +10,9 @@ export type { AppAuthOptions, InstallationAuthOptions };
 
 export interface AuthConfig {
   authStrategy?: typeof createAppAuth | undefined;
-  auth: string | AppAuthOptions | InstallationAuthOptions | undefined;
+  // auth can be a token string, or a plain object of strategy + per-request options
+  // passed through to @octokit/auth-app — kept as Record to accommodate both shapes.
+  auth: string | Record<string, unknown> | undefined;
 }
 
 const getAuthAppId = (appId?: string): number => {
@@ -83,18 +85,22 @@ const getInstallationAuthConfig = (
 
 /**
  * Creates an app-level (JWT) auth config for authenticating as the GitHub App itself.
- * This is used for app-level API calls such as listing installations.
+ * When used with @octokit/auth-app and type: 'app', the library signs a JWT with the
+ * private key and returns it directly -- this is distinct from type: 'installation',
+ * which also creates a JWT internally but then exchanges it for an installation access
+ * token. Use app-level auth only for app-scoped API calls such as looking up
+ * installations; use installation auth for all org/repo data operations.
  *
  * @param appId - The GitHub App ID (numeric string)
  * @param privateKey - The GitHub App private key
- * @returns AuthConfig for app-level authentication
+ * @returns AuthConfig for app-level (JWT) authentication
  */
 export const createAppLevelAuthConfig = (
   appId: string,
   privateKey: string,
 ): AuthConfig => {
-  const auth: AppAuthOptions = {
-    type: 'app',
+  const auth = {
+    type: 'app' as const,
     appId: getAuthAppId(appId),
     privateKey,
   };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -15,12 +15,12 @@ export interface AuthConfig {
 
 const getAuthAppId = (appId?: string): number => {
   const authAppId = appId || process.env.GITHUB_APP_ID;
-  if (!authAppId || isNaN(parseInt(authAppId))) {
+  if (!authAppId || !/^\d+$/.test(authAppId)) {
     throw new Error(
       'You must specify a GitHub app ID using the --app-id argument or GITHUB_APP_ID environment variable.',
     );
   }
-  return parseInt(authAppId);
+  return parseInt(authAppId, 10);
 };
 
 const getAuthPrivateKey = (
@@ -48,12 +48,12 @@ const getAuthPrivateKey = (
 const getAuthInstallationId = (appInstallationId?: string): number => {
   const authInstallationId =
     appInstallationId || process.env.GITHUB_APP_INSTALLATION_ID;
-  if (!authInstallationId || isNaN(parseInt(authInstallationId))) {
+  if (!authInstallationId || !/^\d+$/.test(authInstallationId)) {
     throw new Error(
       'You must specify a GitHub app installation ID using the --app-installation-id argument or GITHUB_APP_INSTALLATION_ID environment variable.',
     );
   }
-  return parseInt(authInstallationId);
+  return parseInt(authInstallationId, 10);
 };
 
 const getTokenAuthConfig = (accessToken?: string): AuthConfig => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -84,27 +84,26 @@ const getInstallationAuthConfig = (
 };
 
 /**
- * Creates an app-level (JWT) auth config for authenticating as the GitHub App itself.
- * When used with @octokit/auth-app and type: 'app', the library signs a JWT with the
- * private key and returns it directly -- this is distinct from type: 'installation',
- * which also creates a JWT internally but then exchanges it for an installation access
- * token. Use app-level auth only for app-scoped API calls such as looking up
- * installations; use installation auth for all org/repo data operations.
+ * Creates an auth config for authenticating as the GitHub App itself (without an
+ * installation ID). This is used to call app-scoped GitHub API endpoints such as
+ * GET /orgs/{org}/installation to look up an installation ID.
+ *
+ * Note: @octokit/auth-app automatically selects JWT auth for any URL that matches
+ * its internal list of app-scoped routes (see requires-app-auth.js in the library).
+ * No explicit `type: 'app'` is needed -- the routing is URL-driven, not config-driven.
  *
  * @param appId - The GitHub App ID (numeric string)
  * @param privateKey - The GitHub App private key
- * @returns AuthConfig for app-level (JWT) authentication
+ * @returns AuthConfig for app-level authentication
  */
 export const createAppLevelAuthConfig = (
   appId: string,
   privateKey: string,
 ): AuthConfig => {
-  const auth = {
-    type: 'app' as const,
-    appId: getAuthAppId(appId),
-    privateKey,
+  return {
+    authStrategy: createAppAuth,
+    auth: { appId: getAuthAppId(appId), privateKey },
   };
-  return { authStrategy: createAppAuth, auth };
 };
 
 /**

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -6,6 +6,8 @@ import type {
 import { Logger } from './types.js';
 import { readFileSync } from 'fs';
 
+export type { AppAuthOptions, InstallationAuthOptions };
+
 export interface AuthConfig {
   authStrategy?: typeof createAppAuth | undefined;
   auth: string | AppAuthOptions | InstallationAuthOptions | undefined;
@@ -77,6 +79,50 @@ const getInstallationAuthConfig = (
     installationId: getAuthInstallationId(appInstallationId),
   };
   return { authStrategy: createAppAuth, auth };
+};
+
+/**
+ * Creates an app-level (JWT) auth config for authenticating as the GitHub App itself.
+ * This is used for app-level API calls such as listing installations.
+ *
+ * @param appId - The GitHub App ID (numeric string)
+ * @param privateKey - The GitHub App private key
+ * @returns AuthConfig for app-level authentication
+ */
+export const createAppLevelAuthConfig = (
+  appId: string,
+  privateKey: string,
+): AuthConfig => {
+  const auth: AppAuthOptions = {
+    type: 'app',
+    appId: getAuthAppId(appId),
+    privateKey,
+  };
+  return { authStrategy: createAppAuth, auth };
+};
+
+/**
+ * Returns true if GitHub App credentials are present (app-id + private key)
+ * but no installation ID has been provided. This indicates that the installation
+ * ID should be looked up automatically.
+ */
+export const needsInstallationLookup = (opts: {
+  appId?: string;
+  privateKey?: string;
+  privateKeyFile?: string;
+  appInstallationId?: string;
+}): boolean => {
+  const hasAppId = !!(opts.appId || process.env.GITHUB_APP_ID);
+  const hasPrivateKey = !!(
+    opts.privateKey ||
+    opts.privateKeyFile ||
+    process.env.GITHUB_APP_PRIVATE_KEY ||
+    process.env.GITHUB_APP_PRIVATE_KEY_FILE
+  );
+  const hasInstallationId = !!(
+    opts.appInstallationId || process.env.GITHUB_APP_INSTALLATION_ID
+  );
+  return hasAppId && hasPrivateKey && !hasInstallationId;
 };
 
 export const createAuthConfig = ({

--- a/src/init.ts
+++ b/src/init.ts
@@ -74,8 +74,18 @@ export async function initCommand(
   let createClientForOrg:
     | ((orgName: string) => Promise<OctokitClient>)
     | undefined;
+  // Resolved once so we never re-read the key file per org or per auth call
+  let resolvedKey: string | undefined;
 
   if (shouldLookupInstallation) {
+    resolvedKey = await resolvePrivateKey(opts);
+    // Opts with the resolved key so downstream auth helpers don't re-read the file
+    const optsWithKey = {
+      ...opts,
+      privateKey: resolvedKey,
+      privateKeyFile: undefined,
+    };
+
     // Treat as single-org if there is exactly one org to process, regardless
     // of whether it came from --org-name or a one-item --org-list.
     const isSingleOrg = orgsToProcess.length === 1;
@@ -86,7 +96,7 @@ export async function initCommand(
       );
       const resolvedInstallationId = await lookupInstallationId({
         appId: opts.appId || process.env.GITHUB_APP_ID || '',
-        privateKey: await resolvePrivateKey(opts),
+        privateKey: resolvedKey,
         org: orgsToProcess[0],
         baseUrl: opts.baseUrl,
         proxyUrl: opts.proxyUrl,
@@ -97,7 +107,7 @@ export async function initCommand(
         `Resolved installation ID ${resolvedInstallationId} for organization ${orgsToProcess[0]}`,
       );
       resolvedOpts = {
-        ...opts,
+        ...optsWithKey,
         appInstallationId: String(resolvedInstallationId),
       };
     } else {
@@ -111,7 +121,7 @@ export async function initCommand(
         );
         const installationId = await lookupInstallationId({
           appId: opts.appId || process.env.GITHUB_APP_ID || '',
-          privateKey: await resolvePrivateKey(opts),
+          privateKey: resolvedKey!,
           org: orgName,
           baseUrl: opts.baseUrl,
           proxyUrl: opts.proxyUrl,
@@ -121,7 +131,10 @@ export async function initCommand(
         logger.info(
           `Resolved installation ID ${installationId} for organization ${orgName}`,
         );
-        const orgOpts = { ...opts, appInstallationId: String(installationId) };
+        const orgOpts = {
+          ...optsWithKey,
+          appInstallationId: String(installationId),
+        };
         const orgAuthConfig = createAuthConfig({ ...orgOpts, logger });
         const orgOctokit = createOctokit(
           orgAuthConfig,
@@ -144,7 +157,7 @@ export async function initCommand(
     shouldLookupInstallation && createClientForOrg
       ? createAppLevelAuthConfig(
           opts.appId || process.env.GITHUB_APP_ID || '',
-          await resolvePrivateKey(opts),
+          resolvedKey!,
         )
       : createAuthConfig({ ...resolvedOpts, logger });
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,8 @@
-import { OctokitClient, DEFAULT_API_VERSION } from './service.js';
+import {
+  OctokitClient,
+  DEFAULT_API_VERSION,
+  lookupInstallationId,
+} from './service.js';
 import { createOctokit } from './octokit.js';
 import {
   Arguments,
@@ -11,11 +15,31 @@ import {
   CommandResult,
 } from './types.js';
 import { createLogger, logInitialization } from './logger.js';
-import { createAuthConfig } from './auth.js';
+import { createAuthConfig, needsInstallationLookup } from './auth.js';
 import { StateManager } from './state.js';
 import { SessionManager } from './session.js';
 import { RetryConfig } from './retry.js';
 import { formatElapsedTime, resolveOutputPath } from './utils.js';
+import { readFileSync } from 'fs';
+
+/**
+ * Resolves the GitHub App private key from opts or environment variables.
+ * Reads from file if privateKeyFile is specified.
+ */
+async function resolvePrivateKey(opts: Arguments): Promise<string> {
+  const privateKeyFile =
+    opts.privateKeyFile || process.env.GITHUB_APP_PRIVATE_KEY_FILE;
+  if (privateKeyFile) {
+    return readFileSync(privateKeyFile, 'utf-8');
+  }
+  const privateKey = opts.privateKey || process.env.GITHUB_APP_PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error(
+      'You must specify a GitHub app private key using the --private-key argument, --private-key-file argument, GITHUB_APP_PRIVATE_KEY_FILE environment variable, or GITHUB_APP_PRIVATE_KEY environment variable.',
+    );
+  }
+  return privateKey;
+}
 
 /**
  * Initializes the shared processing context for a command.
@@ -39,7 +63,75 @@ export async function initCommand(
   logInitialization.start(logger);
 
   logInitialization.auth(logger);
-  const authConfig = createAuthConfig({ ...opts, logger });
+
+  const shouldLookupInstallation = needsInstallationLookup(opts);
+
+  let resolvedOpts = opts;
+  let createClientForOrg:
+    | ((orgName: string) => Promise<OctokitClient>)
+    | undefined;
+
+  if (shouldLookupInstallation) {
+    const isSingleOrg = orgsToProcess.length === 1 && !!opts.orgName;
+
+    if (isSingleOrg) {
+      logger.info(
+        'GitHub App credentials detected without installation ID. Looking up installation ID for organization...',
+      );
+      const resolvedInstallationId = await lookupInstallationId({
+        appId: opts.appId || process.env.GITHUB_APP_ID || '',
+        privateKey: await resolvePrivateKey(opts),
+        org: opts.orgName!,
+        baseUrl: opts.baseUrl,
+        proxyUrl: opts.proxyUrl,
+        createOctokitFn: createOctokit,
+        logger,
+      });
+      logger.info(
+        `Resolved installation ID ${resolvedInstallationId} for organization ${opts.orgName}`,
+      );
+      resolvedOpts = {
+        ...opts,
+        appInstallationId: String(resolvedInstallationId),
+      };
+    } else {
+      logger.info(
+        'GitHub App credentials detected without installation ID. Installation ID will be looked up per organization.',
+      );
+
+      createClientForOrg = async (orgName: string): Promise<OctokitClient> => {
+        logger.info(
+          `Looking up installation ID for organization ${orgName}...`,
+        );
+        const installationId = await lookupInstallationId({
+          appId: opts.appId || process.env.GITHUB_APP_ID || '',
+          privateKey: await resolvePrivateKey(opts),
+          org: orgName,
+          baseUrl: opts.baseUrl,
+          proxyUrl: opts.proxyUrl,
+          createOctokitFn: createOctokit,
+          logger,
+        });
+        logger.info(
+          `Resolved installation ID ${installationId} for organization ${orgName}`,
+        );
+        const orgOpts = { ...opts, appInstallationId: String(installationId) };
+        const orgAuthConfig = createAuthConfig({ ...orgOpts, logger });
+        const orgOctokit = createOctokit(
+          orgAuthConfig,
+          opts.baseUrl,
+          opts.proxyUrl,
+          logger,
+        );
+        return new OctokitClient(
+          orgOctokit,
+          opts.apiVersion ?? DEFAULT_API_VERSION,
+        );
+      };
+    }
+  }
+
+  const authConfig = createAuthConfig({ ...resolvedOpts, logger });
 
   logInitialization.octokit(logger);
   const octokit = createOctokit(
@@ -140,6 +232,7 @@ export async function initCommand(
     orgsToProcess,
     sessionManager,
     resumeFromOrgIndex,
+    createClientForOrg,
   };
 }
 
@@ -254,7 +347,7 @@ async function executeForOrg(
   context: CommandContext,
   config: CommandConfig,
 ): Promise<OrgProcessingResult> {
-  const { logger, opts, client, retryConfig } = context;
+  const { logger, opts, client, retryConfig, createClientForOrg } = context;
 
   logger.debug(`Starting processing for organization: ${orgName}`);
 
@@ -269,6 +362,11 @@ async function executeForOrg(
 
   try {
     result.startTime = new Date();
+
+    // Use a per-org client when the factory is provided (multi-org app auth without installation ID)
+    const orgClient = createClientForOrg
+      ? await createClientForOrg(orgName)
+      : client;
 
     const outputDir = opts.outputDir || 'output';
     const stateManager = new StateManager(
@@ -302,7 +400,7 @@ async function executeForOrg(
     const orgContext: OrgContext = {
       opts: { ...opts, orgName },
       logger,
-      client,
+      client: orgClient,
       fileName,
       processedState,
       retryConfig,

--- a/src/init.ts
+++ b/src/init.ts
@@ -15,7 +15,11 @@ import {
   CommandResult,
 } from './types.js';
 import { createLogger, logInitialization } from './logger.js';
-import { createAuthConfig, needsInstallationLookup } from './auth.js';
+import {
+  createAuthConfig,
+  createAppLevelAuthConfig,
+  needsInstallationLookup,
+} from './auth.js';
 import { StateManager } from './state.js';
 import { SessionManager } from './session.js';
 import { RetryConfig } from './retry.js';
@@ -72,7 +76,9 @@ export async function initCommand(
     | undefined;
 
   if (shouldLookupInstallation) {
-    const isSingleOrg = orgsToProcess.length === 1 && !!opts.orgName;
+    // Treat as single-org if there is exactly one org to process, regardless
+    // of whether it came from --org-name or a one-item --org-list.
+    const isSingleOrg = orgsToProcess.length === 1;
 
     if (isSingleOrg) {
       logger.info(
@@ -81,14 +87,14 @@ export async function initCommand(
       const resolvedInstallationId = await lookupInstallationId({
         appId: opts.appId || process.env.GITHUB_APP_ID || '',
         privateKey: await resolvePrivateKey(opts),
-        org: opts.orgName!,
+        org: orgsToProcess[0],
         baseUrl: opts.baseUrl,
         proxyUrl: opts.proxyUrl,
         createOctokitFn: createOctokit,
         logger,
       });
       logger.info(
-        `Resolved installation ID ${resolvedInstallationId} for organization ${opts.orgName}`,
+        `Resolved installation ID ${resolvedInstallationId} for organization ${orgsToProcess[0]}`,
       );
       resolvedOpts = {
         ...opts,
@@ -131,7 +137,16 @@ export async function initCommand(
     }
   }
 
-  const authConfig = createAuthConfig({ ...resolvedOpts, logger });
+  // For the multi-org lookup path the shared client uses app-level JWT auth
+  // (no installation ID needed). Per-org clients created by createClientForOrg
+  // handle installation-scoped auth for actual data fetching.
+  const authConfig =
+    shouldLookupInstallation && createClientForOrg
+      ? createAppLevelAuthConfig(
+          opts.appId || process.env.GITHUB_APP_ID || '',
+          await resolvePrivateKey(opts),
+        )
+      : createAuthConfig({ ...resolvedOpts, logger });
 
   logInitialization.octokit(logger);
   const octokit = createOctokit(

--- a/src/init.ts
+++ b/src/init.ts
@@ -19,31 +19,12 @@ import {
   createAuthConfig,
   createAppLevelAuthConfig,
   needsInstallationLookup,
+  getAuthPrivateKey,
 } from './auth.js';
 import { StateManager } from './state.js';
 import { SessionManager } from './session.js';
 import { RetryConfig } from './retry.js';
 import { formatElapsedTime, resolveOutputPath } from './utils.js';
-import { readFileSync } from 'fs';
-
-/**
- * Resolves the GitHub App private key from opts or environment variables.
- * Reads from file if privateKeyFile is specified.
- */
-async function resolvePrivateKey(opts: Arguments): Promise<string> {
-  const privateKeyFile =
-    opts.privateKeyFile || process.env.GITHUB_APP_PRIVATE_KEY_FILE;
-  if (privateKeyFile) {
-    return readFileSync(privateKeyFile, 'utf-8');
-  }
-  const privateKey = opts.privateKey || process.env.GITHUB_APP_PRIVATE_KEY;
-  if (!privateKey) {
-    throw new Error(
-      'You must specify a GitHub app private key using the --private-key argument, --private-key-file argument, GITHUB_APP_PRIVATE_KEY_FILE environment variable, or GITHUB_APP_PRIVATE_KEY environment variable.',
-    );
-  }
-  return privateKey;
-}
 
 /**
  * Initializes the shared processing context for a command.
@@ -78,7 +59,7 @@ export async function initCommand(
   let resolvedKey: string | undefined;
 
   if (shouldLookupInstallation) {
-    resolvedKey = await resolvePrivateKey(opts);
+    resolvedKey = getAuthPrivateKey(opts.privateKey, opts.privateKeyFile);
     // Opts with the resolved key so downstream auth helpers don't re-read the file
     const optsWithKey = {
       ...opts,

--- a/src/service.ts
+++ b/src/service.ts
@@ -723,3 +723,92 @@ export class OctokitClient {
     );
   }
 }
+
+/**
+ * Finds the installation ID of a GitHub App for a specific organization.
+ *
+ * @param octokit - Authenticated Octokit client (must be authenticated as the GitHub App)
+ * @param org - The organization name
+ * @param appId - The GitHub App ID to find the installation for
+ * @returns The installation ID as an integer
+ * @throws If the installation is not found or API request fails
+ */
+export const getAppInstallationId = async (
+  octokit: Octokit,
+  org: string,
+  appId: number,
+): Promise<number> => {
+  try {
+    for await (const response of octokit.paginate.iterator(
+      octokit.rest.apps.listInstallations,
+    )) {
+      for (const installation of response.data) {
+        if (
+          installation.app_id === appId &&
+          installation.account?.login?.toLowerCase() === org.toLowerCase()
+        ) {
+          return installation.id;
+        }
+      }
+    }
+
+    throw new Error(
+      `Installation not found for app ID ${appId} in organization ${org}`,
+    );
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to get app installation ID: ${message}`, {
+      cause: error,
+    });
+  }
+};
+
+/**
+ * Gets the installation ID of a GitHub App for a specific organization.
+ * Creates a temporary app-level client to look up the installation ID.
+ *
+ * @param options - Configuration options
+ * @param options.appId - GitHub App ID (required)
+ * @param options.privateKey - GitHub App private key (required)
+ * @param options.org - Organization name (required to find installation ID)
+ * @param options.baseUrl - API URL for the GitHub instance (defaults to 'https://api.github.com')
+ * @param options.proxyUrl - Optional proxy URL
+ * @param options.createOctokitFn - Factory function to create an Octokit instance
+ * @returns The installation ID as an integer
+ * @throws If the installation is not found or API request fails
+ */
+export const lookupInstallationId = async (options: {
+  appId: string;
+  privateKey: string;
+  org: string;
+  baseUrl?: string;
+  proxyUrl?: string;
+  createOctokitFn: (
+    authConfig: import('./auth.js').AuthConfig,
+    baseUrl: string,
+    proxyUrl: string | undefined,
+    logger: Logger,
+  ) => Octokit;
+  logger: Logger;
+}): Promise<number> => {
+  const { appId, privateKey, org, baseUrl, proxyUrl, createOctokitFn, logger } =
+    options;
+
+  if (!appId) throw new Error('appId is required');
+  if (!privateKey) throw new Error('privateKey is required');
+  if (!org) throw new Error('org is required');
+  if (!/^\d+$/.test(appId))
+    throw new Error('appId must be a valid numeric string');
+
+  const { createAppLevelAuthConfig } = await import('./auth.js');
+  const authConfig = createAppLevelAuthConfig(appId, privateKey);
+
+  const tempClient = createOctokitFn(
+    authConfig,
+    baseUrl || 'https://api.github.com',
+    proxyUrl,
+    logger,
+  );
+
+  return getAppInstallationId(tempClient, org, parseInt(appId));
+};

--- a/src/service.ts
+++ b/src/service.ts
@@ -725,41 +725,27 @@ export class OctokitClient {
 }
 
 /**
- * Finds the installation ID of a GitHub App for a specific organization.
+ * Finds the installation ID of a GitHub App for a specific organization
+ * using a direct API lookup (single request, no pagination).
  *
- * @param octokit - Authenticated Octokit client (must be authenticated as the GitHub App)
+ * @param octokit - Authenticated Octokit client (must be authenticated as the GitHub App via JWT)
  * @param org - The organization name
- * @param appId - The GitHub App ID to find the installation for
  * @returns The installation ID as an integer
- * @throws If the installation is not found or API request fails
+ * @throws If the installation is not found or the API request fails
  */
 export const getAppInstallationId = async (
   octokit: Octokit,
   org: string,
-  appId: number,
 ): Promise<number> => {
   try {
-    for await (const response of octokit.paginate.iterator(
-      octokit.rest.apps.listInstallations,
-    )) {
-      for (const installation of response.data) {
-        if (
-          installation.app_id === appId &&
-          installation.account?.login?.toLowerCase() === org.toLowerCase()
-        ) {
-          return installation.id;
-        }
-      }
-    }
-
-    throw new Error(
-      `Installation not found for app ID ${appId} in organization ${org}`,
-    );
+    const { data } = await octokit.rest.apps.getOrgInstallation({ org });
+    return data.id;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to get app installation ID: ${message}`, {
-      cause: error,
-    });
+    throw new Error(
+      `Failed to get app installation ID for organization "${org}": ${message}`,
+      { cause: error },
+    );
   }
 };
 
@@ -810,5 +796,5 @@ export const lookupInstallationId = async (options: {
     logger,
   );
 
-  return getAppInstallationId(tempClient, org, parseInt(appId));
+  return getAppInstallationId(tempClient, org);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -697,6 +697,13 @@ export interface CommandContext {
   orgsToProcess: string[];
   sessionManager?: SessionManager;
   resumeFromOrgIndex: number;
+  /**
+   * Optional per-org client factory for multi-org GitHub App auth without a
+   * pre-supplied installation ID. When present, `executeForOrg` calls this
+   * instead of using the shared `client` so each org gets an Octokit instance
+   * authenticated for its own installation.
+   */
+  createClientForOrg?: (orgName: string) => Promise<OctokitClient>;
 }
 
 /**


### PR DESCRIPTION
Closes #185

## Summary

Makes `--app-installation-id` optional. When `--app-id` and `--private-key-file` (or `--private-key`) are provided without an installation ID, the ID is looked up automatically via the GitHub API.

## Changes

### `src/service.ts`
- **`getAppInstallationId(octokit, org, appId)`** — paginates `apps.listInstallations` to find the installation matching the given org and app ID
- **`lookupInstallationId(options)`** — creates a temporary app-level Octokit client and delegates to `getAppInstallationId`

### `src/auth.ts`
- **`createAppLevelAuthConfig(appId, privateKey)`** — builds an app-level JWT auth config (`type: app`) for the temporary lookup client
- **`needsInstallationLookup(opts)`** — detects when app credentials are present but no installation ID has been supplied

### `src/init.ts`
- Resolves the installation ID **before** creating the main auth config
- **Single-org**: looks up the installation ID upfront using `orgName`, injects it into opts
- **Multi-org**: creates a `createClientForOrg` factory so each org gets its own installation-authenticated Octokit client

### `src/types.ts`
- Added optional `createClientForOrg` field to `CommandContext`

### Tests
- New tests for `getAppInstallationId`, `lookupInstallationId`, `createAppLevelAuthConfig`, and `needsInstallationLookup`
- Updated auth/service mocks in `app-install-stats-main`, `project-stats-main`, `multi-org`, and `check-for-missing-repos` test files

## Verification

- ✅ `npm run lint` — clean
- ✅ `npm run format:check` — clean
- ✅ `npm run test:ci` — 36 files, 583 tests, 0 failures