### PR TITLE
feat: add CA certificate support for GHES TLS verification

### DIFF
--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -355,4 +355,24 @@ describe('Commands', () => {
       expect(option?.envVar).toBe('GITHUB_API_VERSION');
     });
   });
+
+  describe('TLS options', () => {
+    it('should have --ca-cert option on repo-stats command', () => {
+      const option = repoStatsCommand.options.find(
+        (opt) => opt.long === '--ca-cert',
+      );
+      expect(option).toBeDefined();
+      expect(option?.description).toContain('CA certificate');
+      expect(option?.envVar).toBe('NODE_EXTRA_CA_CERTS');
+    });
+
+    it('should have --ca-cert option on missing-repos command', () => {
+      const option = missingReposCommand.options.find(
+        (opt) => opt.long === '--ca-cert',
+      );
+      expect(option).toBeDefined();
+      expect(option?.description).toContain('CA certificate');
+      expect(option?.envVar).toBe('NODE_EXTRA_CA_CERTS');
+    });
+  });
 });

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -1,11 +1,31 @@
 import { describe, it, expect, vi } from 'vitest';
 import repoStatsCommand from '../src/commands/repo-stats-command.js';
 import missingReposCommand from '../src/commands/missing-repos-command.js';
+import projectStatsCommand from '../src/commands/project-stats-command.js';
+import appInstallStatsCommand from '../src/commands/app-install-stats-command.js';
+import packageStatsCommand from '../src/commands/package-stats-command.js';
+import codespaceStatsCommand from '../src/commands/codespace-stats-command.js';
 
 // Mock the main module functions
 vi.mock('../src/main.js', () => ({
   run: vi.fn(),
   checkForMissingRepos: vi.fn(),
+}));
+
+vi.mock('../src/projects.js', () => ({
+  runProjectStats: vi.fn(),
+}));
+
+vi.mock('../src/app-installs.js', () => ({
+  runAppInstallStats: vi.fn(),
+}));
+
+vi.mock('../src/packages.js', () => ({
+  runPackageStats: vi.fn(),
+}));
+
+vi.mock('../src/codespaces.js', () => ({
+  runCodespaceStats: vi.fn(),
 }));
 
 describe('Commands', () => {
@@ -357,22 +377,22 @@ describe('Commands', () => {
   });
 
   describe('TLS options', () => {
-    it('should have --ca-cert option on repo-stats command', () => {
-      const option = repoStatsCommand.options.find(
-        (opt) => opt.long === '--ca-cert',
-      );
-      expect(option).toBeDefined();
-      expect(option?.description).toContain('CA certificate');
-      expect(option?.envVar).toBe('NODE_EXTRA_CA_CERTS');
-    });
+    const commandsToTest = [
+      { name: 'repo-stats', command: repoStatsCommand },
+      { name: 'missing-repos', command: missingReposCommand },
+      { name: 'project-stats', command: projectStatsCommand },
+      { name: 'app-install-stats', command: appInstallStatsCommand },
+      { name: 'package-stats', command: packageStatsCommand },
+      { name: 'codespace-stats', command: codespaceStatsCommand },
+    ];
 
-    it('should have --ca-cert option on missing-repos command', () => {
-      const option = missingReposCommand.options.find(
-        (opt) => opt.long === '--ca-cert',
-      );
-      expect(option).toBeDefined();
-      expect(option?.description).toContain('CA certificate');
-      expect(option?.envVar).toBe('NODE_EXTRA_CA_CERTS');
+    commandsToTest.forEach(({ name, command }) => {
+      it(`should have --ca-cert option on ${name} command`, () => {
+        const option = command.options.find((opt) => opt.long === '--ca-cert');
+        expect(option).toBeDefined();
+        expect(option?.description).toContain('CA certificate');
+        expect(option?.envVar).toBe('NODE_EXTRA_CA_CERTS');
+      });
     });
   });
 });

--- a/__tests__/octokit.test.ts
+++ b/__tests__/octokit.test.ts
@@ -6,6 +6,7 @@ import type { AuthConfig } from '../src/auth.js';
 // Mock external dependencies
 vi.mock('undici', () => ({
   fetch: vi.fn(),
+  Agent: vi.fn(),
   ProxyAgent: vi.fn(),
 }));
 
@@ -129,6 +130,45 @@ describe('octokit', () => {
 
       // Assert
       expect(result).toBeDefined();
+    });
+
+    it('should configure CA certificate when caCert is provided', () => {
+      // Arrange
+      const caCert =
+        '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----';
+      const baseUrl = 'https://ghes.example.com/api/v3';
+
+      // Act & Assert - Should not throw
+      expect(() => {
+        createOctokit(
+          mockAuthConfig,
+          baseUrl,
+          undefined,
+          mockLogger,
+          undefined,
+          caCert,
+        );
+      }).not.toThrow();
+    });
+
+    it('should configure CA certificate with proxy when both are provided', () => {
+      // Arrange
+      const caCert =
+        '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----';
+      const proxyUrl = 'http://proxy.example.com:8080';
+      const baseUrl = 'https://ghes.example.com/api/v3';
+
+      // Act & Assert - Should not throw
+      expect(() => {
+        createOctokit(
+          mockAuthConfig,
+          baseUrl,
+          proxyUrl,
+          mockLogger,
+          undefined,
+          caCert,
+        );
+      }).not.toThrow();
     });
 
     describe('hook handlers', () => {

--- a/__tests__/octokit.test.ts
+++ b/__tests__/octokit.test.ts
@@ -10,6 +10,11 @@ vi.mock('undici', () => ({
   ProxyAgent: vi.fn(),
 }));
 
+import { Agent, ProxyAgent } from 'undici';
+
+const MockAgent = vi.mocked(Agent);
+const MockProxyAgent = vi.mocked(ProxyAgent);
+
 vi.mock('octokit', () => {
   const mockOctokit = {
     hook: {
@@ -65,62 +70,66 @@ describe('octokit', () => {
 
   describe('createOctokit', () => {
     it('should create Octokit instance with basic configuration', () => {
-      // Arrange
-      const baseUrl = 'https://api.github.com';
-
-      // Act
       const result = createOctokit(
         mockAuthConfig,
-        baseUrl,
+        'https://api.github.com',
         undefined,
         mockLogger,
       );
 
-      // Assert
       expect(result).toBeDefined();
       expect(result.hook).toBeDefined();
       expect(result.hook.after).toBeInstanceOf(Function);
       expect(result.hook.error).toBeInstanceOf(Function);
     });
 
-    it('should configure proxy when proxyUrl is provided', () => {
-      // Arrange
-      const proxyUrl = 'http://proxy.example.com:8080';
-      const baseUrl = 'https://api.github.com';
+    it('should not create any dispatcher when no proxy or caCert', () => {
+      createOctokit(
+        mockAuthConfig,
+        'https://api.github.com',
+        undefined,
+        mockLogger,
+      );
 
-      // Act & Assert - Simply test that the function doesn't throw
-      expect(() => {
-        createOctokit(mockAuthConfig, baseUrl, proxyUrl, mockLogger);
-      }).not.toThrow();
+      expect(MockAgent).not.toHaveBeenCalled();
+      expect(MockProxyAgent).not.toHaveBeenCalled();
+    });
+
+    it('should configure ProxyAgent when proxyUrl is provided', () => {
+      createOctokit(
+        mockAuthConfig,
+        'https://api.github.com',
+        'http://proxy.example.com:8080',
+        mockLogger,
+      );
+
+      expect(MockProxyAgent).toHaveBeenCalledWith(
+        'http://proxy.example.com:8080',
+      );
+      expect(MockAgent).not.toHaveBeenCalled();
     });
 
     it('should use custom fetch function when provided', () => {
-      // Arrange
       const customFetch = vi.fn();
-      const baseUrl = 'https://api.github.com';
 
-      // Act
       const result = createOctokit(
         mockAuthConfig,
-        baseUrl,
+        'https://api.github.com',
         undefined,
         mockLogger,
-        customFetch,
+        { fetch: customFetch },
       );
 
-      // Assert
       expect(result).toBeDefined();
     });
 
     it('should configure auth strategy when provided', () => {
-      // Arrange
       const mockAuthStrategy = vi.fn();
       const authConfigWithStrategy: AuthConfig = {
         authStrategy: mockAuthStrategy,
         auth: { type: 'installation', appId: 123 },
       };
 
-      // Act
       const result = createOctokit(
         authConfigWithStrategy,
         'https://api.github.com',
@@ -128,52 +137,51 @@ describe('octokit', () => {
         mockLogger,
       );
 
-      // Assert
       expect(result).toBeDefined();
     });
 
-    it('should configure CA certificate when caCert is provided', () => {
-      // Arrange
+    it('should create Agent with CA cert when caCert is provided without proxy', () => {
       const caCert =
         '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----';
-      const baseUrl = 'https://ghes.example.com/api/v3';
 
-      // Act & Assert - Should not throw
-      expect(() => {
-        createOctokit(
-          mockAuthConfig,
-          baseUrl,
-          undefined,
-          mockLogger,
-          undefined,
+      createOctokit(
+        mockAuthConfig,
+        'https://ghes.example.com/api/v3',
+        undefined,
+        mockLogger,
+        {
           caCert,
-        );
-      }).not.toThrow();
+        },
+      );
+
+      expect(MockAgent).toHaveBeenCalledWith({ connect: { ca: caCert } });
+      expect(MockProxyAgent).not.toHaveBeenCalled();
     });
 
-    it('should configure CA certificate with proxy when both are provided', () => {
-      // Arrange
+    it('should create ProxyAgent with requestTls when both proxy and caCert are provided', () => {
       const caCert =
         '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----';
       const proxyUrl = 'http://proxy.example.com:8080';
-      const baseUrl = 'https://ghes.example.com/api/v3';
 
-      // Act & Assert - Should not throw
-      expect(() => {
-        createOctokit(
-          mockAuthConfig,
-          baseUrl,
-          proxyUrl,
-          mockLogger,
-          undefined,
+      createOctokit(
+        mockAuthConfig,
+        'https://ghes.example.com/api/v3',
+        proxyUrl,
+        mockLogger,
+        {
           caCert,
-        );
-      }).not.toThrow();
+        },
+      );
+
+      expect(MockProxyAgent).toHaveBeenCalledWith({
+        uri: proxyUrl,
+        requestTls: { ca: caCert },
+      });
+      expect(MockAgent).not.toHaveBeenCalled();
     });
 
     describe('hook handlers', () => {
       it('should have after and error hooks configured', () => {
-        // Arrange
         const result = createOctokit(
           mockAuthConfig,
           'https://api.github.com',
@@ -181,7 +189,6 @@ describe('octokit', () => {
           mockLogger,
         );
 
-        // Assert
         expect(result.hook.after).toHaveBeenCalled();
         expect(result.hook.error).toHaveBeenCalled();
       });

--- a/__tests__/tls.test.ts
+++ b/__tests__/tls.test.ts
@@ -87,7 +87,7 @@ describe('tls', () => {
       });
 
       expect(() => loadCaCertificate('/missing/ca.pem', logger)).toThrow(
-        'Failed to read CA certificate from --ca-cert (/missing/ca.pem): ENOENT: no such file or directory',
+        'Failed to read CA certificate from --ca-cert: ENOENT: no such file or directory',
       );
     });
 
@@ -98,7 +98,7 @@ describe('tls', () => {
       });
 
       expect(() => loadCaCertificate(undefined, logger)).toThrow(
-        'Failed to read CA certificate from NODE_EXTRA_CA_CERTS (/missing/env-ca.pem): EACCES: permission denied',
+        'Failed to read CA certificate from NODE_EXTRA_CA_CERTS: EACCES: permission denied',
       );
     });
 
@@ -108,7 +108,7 @@ describe('tls', () => {
       });
 
       expect(() => loadCaCertificate('/bad/ca.pem', logger)).toThrow(
-        'Failed to read CA certificate from --ca-cert (/bad/ca.pem): Unknown error reading file',
+        'Failed to read CA certificate from --ca-cert: Unknown error reading file',
       );
     });
   });

--- a/__tests__/tls.test.ts
+++ b/__tests__/tls.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadCaCertificate } from '../src/tls.js';
+import { createMockLogger } from './test-utils.js';
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+import { readFileSync } from 'fs';
+
+const mockReadFileSync = vi.mocked(readFileSync);
+
+describe('tls', () => {
+  const logger = createMockLogger();
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.NODE_EXTRA_CA_CERTS;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('loadCaCertificate', () => {
+    it('should return undefined when no path or env var is set', () => {
+      const result = loadCaCertificate(undefined, logger);
+      expect(result).toBeUndefined();
+      expect(mockReadFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should load certificate from explicit path', () => {
+      const certContent =
+        '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----';
+      mockReadFileSync.mockReturnValue(certContent);
+
+      const result = loadCaCertificate('/path/to/ca.pem', logger);
+
+      expect(result).toBe(certContent);
+      expect(mockReadFileSync).toHaveBeenCalledWith('/path/to/ca.pem', 'utf-8');
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('--ca-cert'),
+      );
+    });
+
+    it('should fall back to NODE_EXTRA_CA_CERTS env var', () => {
+      const certContent =
+        '-----BEGIN CERTIFICATE-----\nenv\n-----END CERTIFICATE-----';
+      process.env.NODE_EXTRA_CA_CERTS = '/env/path/ca.pem';
+      mockReadFileSync.mockReturnValue(certContent);
+
+      const result = loadCaCertificate(undefined, logger);
+
+      expect(result).toBe(certContent);
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        '/env/path/ca.pem',
+        'utf-8',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('NODE_EXTRA_CA_CERTS'),
+      );
+    });
+
+    it('should prefer explicit path over NODE_EXTRA_CA_CERTS', () => {
+      const certContent =
+        '-----BEGIN CERTIFICATE-----\nexplicit\n-----END CERTIFICATE-----';
+      process.env.NODE_EXTRA_CA_CERTS = '/env/path/ca.pem';
+      mockReadFileSync.mockReturnValue(certContent);
+
+      const result = loadCaCertificate('/explicit/path/ca.pem', logger);
+
+      expect(result).toBe(certContent);
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        '/explicit/path/ca.pem',
+        'utf-8',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('--ca-cert'),
+      );
+    });
+
+    it('should throw error when file cannot be read', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('ENOENT: no such file or directory');
+      });
+
+      expect(() => loadCaCertificate('/missing/ca.pem', logger)).toThrow(
+        'Failed to read CA certificate from --ca-cert (/missing/ca.pem): ENOENT: no such file or directory',
+      );
+    });
+
+    it('should throw error when NODE_EXTRA_CA_CERTS file cannot be read', () => {
+      process.env.NODE_EXTRA_CA_CERTS = '/missing/env-ca.pem';
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      expect(() => loadCaCertificate(undefined, logger)).toThrow(
+        'Failed to read CA certificate from NODE_EXTRA_CA_CERTS (/missing/env-ca.pem): EACCES: permission denied',
+      );
+    });
+
+    it('should handle non-Error throw from readFileSync', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw 'unexpected string error';
+      });
+
+      expect(() => loadCaCertificate('/bad/ca.pem', logger)).toThrow(
+        'Failed to read CA certificate from --ca-cert (/bad/ca.pem): Unknown error reading file',
+      );
+    });
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -53,10 +53,10 @@ inputs:
     description: "GitHub API base URL"
     required: false
     default: "https://api.github.com"
-  skip-tls-verification:
-    description: "Skip TLS certificate verification for the target GitHub instance (use for GHES with self-signed certs or IP-based access)"
+  ca-cert-path:
+    description: "Path to CA certificate bundle (PEM) for TLS verification against GHES instances with internal or self-signed certificates"
     required: false
-    default: "false"
+    default: ""
   retention-days:
     description: "Number of days to retain artifacts"
     required: false
@@ -202,60 +202,23 @@ runs:
         echo "gh_host=${HOST}" >> $GITHUB_OUTPUT
         echo "✓ Resolved GH_HOST: ${HOST}"
 
-    - name: Configure TLS for GHES
-      if: ${{ inputs.skip-tls-verification == 'true' }}
+    - name: Configure CA Certificate for GHES
+      if: ${{ inputs.ca-cert-path != '' }}
       shell: bash
       run: |
-        HOST="${{ steps.resolve-host.outputs.gh_host }}"
+        CA_CERT_PATH="${{ inputs.ca-cert-path }}"
 
-        # Guard: refuse to disable TLS for public github.com
-        if [[ "$HOST" == "github.com" ]]; then
-          echo "::error::Refusing to disable TLS verification for public github.com. Remove 'skip-tls-verification' or use a GHES base-url."
+        if [[ ! -f "$CA_CERT_PATH" ]]; then
+          echo "::error::CA certificate file not found: ${CA_CERT_PATH}"
           exit 1
         fi
 
-        echo "Configuring TLS bypass for non-github.com host: ${HOST}"
+        echo "Configuring CA certificate for TLS verification: ${CA_CERT_PATH}"
 
-        # Disable SSL verification for Node.js (Octokit/actions)
-        echo "NODE_TLS_REJECT_UNAUTHORIZED=0" >> $GITHUB_ENV
+        # Make the CA cert available to Node.js via NODE_EXTRA_CA_CERTS
+        echo "NODE_EXTRA_CA_CERTS=${CA_CERT_PATH}" >> $GITHUB_ENV
 
-        # Suppress Node.js TLS warnings
-        echo "NODE_NO_WARNINGS=1" >> $GITHUB_ENV
-
-        # Disable SSL verification for Git operations scoped to the GHES host
-        git config --global "http.https://${HOST}/.sslVerify" false
-
-        # Disable SSL verification for gh CLI (Go-based, not affected by NODE_TLS)
-        # skip_tls_verification requires gh >= 2.54.0
-        GH_VERSION=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-        echo "  gh CLI version: ${GH_VERSION}"
-        GH_MAJOR=$(echo "$GH_VERSION" | cut -d. -f1)
-        GH_MINOR=$(echo "$GH_VERSION" | cut -d. -f2)
-        if [[ "$GH_MAJOR" -gt 2 ]] || { [[ "$GH_MAJOR" -eq 2 ]] && [[ "$GH_MINOR" -ge 54 ]]; }; then
-          gh config set -h "${HOST}" skip_tls_verification true
-          echo "✓ TLS bypass configured via gh config for ${HOST}"
-        else
-          echo "⚠️  gh CLI ${GH_VERSION} does not support skip_tls_verification (requires >= 2.54.0)"
-          echo "  Attempting to upgrade gh CLI..."
-          if command -v apt-get &> /dev/null; then
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt-get update -qq && sudo apt-get install -qq -y gh > /dev/null 2>&1
-          elif command -v brew &> /dev/null; then
-            brew upgrade gh 2>/dev/null || brew install gh 2>/dev/null
-          fi
-          NEW_VERSION=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          echo "  gh CLI version after upgrade: ${NEW_VERSION}"
-          NEW_MAJOR=$(echo "$NEW_VERSION" | cut -d. -f1)
-          NEW_MINOR=$(echo "$NEW_VERSION" | cut -d. -f2)
-          if [[ "$NEW_MAJOR" -gt 2 ]] || { [[ "$NEW_MAJOR" -eq 2 ]] && [[ "$NEW_MINOR" -ge 54 ]]; }; then
-            gh config set -h "${HOST}" skip_tls_verification true
-          else
-            echo "::warning::gh CLI ${NEW_VERSION} still does not support skip_tls_verification. gh API calls to GHES may fail with TLS errors. Node.js, Git, and curl TLS bypass are still active."
-          fi
-        fi
-
-        echo "✓ TLS bypass configured for ${HOST}"
+        echo "✓ CA certificate configured for TLS verification"
 
     - name: Setup Paths
       id: setup-paths
@@ -299,18 +262,17 @@ runs:
         GH_HOST: ${{ steps.resolve-host.outputs.gh_host }}
         BASE_URL: ${{ inputs.base-url }}
         TOKEN_SOURCE: ${{ steps.app-install.outputs.token != '' && 'GitHub App' || (inputs.access-token != '' && 'Access Token' || 'github-token (fallback)') }}
-        SKIP_TLS: ${{ inputs.skip-tls-verification }}
+        CA_CERT_PATH: ${{ inputs.ca-cert-path }}
       run: |
         echo "Validating repository: ${{ inputs.organization }}/${{ inputs.repository }}"
         echo "  GH_HOST: ${GH_HOST}"
         echo "  Base URL: ${BASE_URL}"
         echo "  Token length: ${#GH_TOKEN}"
         echo "  Token source: ${TOKEN_SOURCE}"
-        echo "  Skip TLS: ${SKIP_TLS}"
 
         CURL_OPTS=(-s --max-time 15)
-        if [[ "${SKIP_TLS}" == "true" ]]; then
-          CURL_OPTS+=(-k)
+        if [[ -n "${CA_CERT_PATH}" ]]; then
+          CURL_OPTS+=(--cacert "${CA_CERT_PATH}")
         fi
 
         HTTP_CODE=$(curl "${CURL_OPTS[@]}" \
@@ -357,18 +319,17 @@ runs:
         GH_HOST: ${{ steps.resolve-host.outputs.gh_host }}
         BASE_URL: ${{ inputs.base-url }}
         TOKEN_SOURCE: ${{ steps.app-install.outputs.token != '' && 'GitHub App' || (inputs.access-token != '' && 'Access Token' || 'github-token (fallback)') }}
-        SKIP_TLS: ${{ inputs.skip-tls-verification }}
+        CA_CERT_PATH: ${{ inputs.ca-cert-path }}
       run: |
         echo "Validating organization: ${{ inputs.organization }}"
         echo "  GH_HOST: ${GH_HOST}"
         echo "  Base URL: ${BASE_URL}"
         echo "  Token length: ${#GH_TOKEN}"
         echo "  Token source: ${TOKEN_SOURCE}"
-        echo "  Skip TLS: ${SKIP_TLS}"
 
         CURL_OPTS=(-s --max-time 15)
-        if [[ "${SKIP_TLS}" == "true" ]]; then
-          CURL_OPTS+=(-k)
+        if [[ -n "${CA_CERT_PATH}" ]]; then
+          CURL_OPTS+=(--cacert "${CA_CERT_PATH}")
         fi
 
         HTTP_CODE=$(curl "${CURL_OPTS[@]}" \

--- a/action.yml
+++ b/action.yml
@@ -53,8 +53,12 @@ inputs:
     description: "GitHub API base URL"
     required: false
     default: "https://api.github.com"
+  ca-cert:
+    description: "CA certificate bundle content (PEM) for TLS verification against GHES instances. Use this when the certificate is stored as a GitHub secret (e.g., ${{ secrets.GHES_CA_CERT }}). The action writes it to a temporary file automatically."
+    required: false
+    default: ""
   ca-cert-path:
-    description: "Path to CA certificate bundle (PEM) for TLS verification against GHES instances with internal or self-signed certificates"
+    description: "Path to a CA certificate bundle file (PEM) on the runner for TLS verification against GHES instances. Use ca-cert instead when the certificate is stored as a secret."
     required: false
     default: ""
   retention-days:
@@ -203,17 +207,30 @@ runs:
         echo "✓ Resolved GH_HOST: ${HOST}"
 
     - name: Configure CA Certificate for GHES
-      if: ${{ inputs.ca-cert-path != '' }}
+      if: ${{ inputs.ca-cert != '' || inputs.ca-cert-path != '' }}
       shell: bash
+      env:
+        CA_CERT_CONTENT: ${{ inputs.ca-cert }}
+        CA_CERT_FILE: ${{ inputs.ca-cert-path }}
       run: |
-        CA_CERT_PATH="${{ inputs.ca-cert-path }}"
-
-        if [[ ! -f "$CA_CERT_PATH" ]]; then
-          echo "::error::CA certificate file not found: ${CA_CERT_PATH}"
+        if [[ -n "${CA_CERT_CONTENT}" ]] && [[ -n "${CA_CERT_FILE}" ]]; then
+          echo "::error::Specify either 'ca-cert' (secret content) or 'ca-cert-path' (file path), not both."
           exit 1
         fi
 
-        echo "Configuring CA certificate for TLS verification: ${CA_CERT_PATH}"
+        if [[ -n "${CA_CERT_CONTENT}" ]]; then
+          # Write secret content to a temporary file
+          CA_CERT_PATH=$(mktemp "${RUNNER_TEMP:-/tmp}/ca-cert-XXXXXX.pem")
+          echo "${CA_CERT_CONTENT}" > "${CA_CERT_PATH}"
+          echo "✓ Wrote CA certificate from secret to temporary file"
+        else
+          CA_CERT_PATH="${CA_CERT_FILE}"
+          if [[ ! -f "${CA_CERT_PATH}" ]]; then
+            echo "::error::CA certificate file not found at ca-cert-path"
+            exit 1
+          fi
+          echo "✓ Using CA certificate from file path"
+        fi
 
         # Make the CA cert available to Node.js via NODE_EXTRA_CA_CERTS
         echo "NODE_EXTRA_CA_CERTS=${CA_CERT_PATH}" >> $GITHUB_ENV
@@ -262,7 +279,6 @@ runs:
         GH_HOST: ${{ steps.resolve-host.outputs.gh_host }}
         BASE_URL: ${{ inputs.base-url }}
         TOKEN_SOURCE: ${{ steps.app-install.outputs.token != '' && 'GitHub App' || (inputs.access-token != '' && 'Access Token' || 'github-token (fallback)') }}
-        CA_CERT_PATH: ${{ inputs.ca-cert-path }}
       run: |
         echo "Validating repository: ${{ inputs.organization }}/${{ inputs.repository }}"
         echo "  GH_HOST: ${GH_HOST}"
@@ -271,8 +287,8 @@ runs:
         echo "  Token source: ${TOKEN_SOURCE}"
 
         CURL_OPTS=(-s --max-time 15)
-        if [[ -n "${CA_CERT_PATH}" ]]; then
-          CURL_OPTS+=(--cacert "${CA_CERT_PATH}")
+        if [[ -n "${NODE_EXTRA_CA_CERTS}" ]]; then
+          CURL_OPTS+=(--cacert "${NODE_EXTRA_CA_CERTS}")
         fi
 
         HTTP_CODE=$(curl "${CURL_OPTS[@]}" \
@@ -319,7 +335,6 @@ runs:
         GH_HOST: ${{ steps.resolve-host.outputs.gh_host }}
         BASE_URL: ${{ inputs.base-url }}
         TOKEN_SOURCE: ${{ steps.app-install.outputs.token != '' && 'GitHub App' || (inputs.access-token != '' && 'Access Token' || 'github-token (fallback)') }}
-        CA_CERT_PATH: ${{ inputs.ca-cert-path }}
       run: |
         echo "Validating organization: ${{ inputs.organization }}"
         echo "  GH_HOST: ${GH_HOST}"
@@ -328,8 +343,8 @@ runs:
         echo "  Token source: ${TOKEN_SOURCE}"
 
         CURL_OPTS=(-s --max-time 15)
-        if [[ -n "${CA_CERT_PATH}" ]]; then
-          CURL_OPTS+=(--cacert "${CA_CERT_PATH}")
+        if [[ -n "${NODE_EXTRA_CA_CERTS}" ]]; then
+          CURL_OPTS+=(--cacert "${NODE_EXTRA_CA_CERTS}")
         fi
 
         HTTP_CODE=$(curl "${CURL_OPTS[@]}" \

--- a/action/README.md
+++ b/action/README.md
@@ -35,7 +35,8 @@ In both cases, the `github-token` input (typically `${{ secrets.GITHUB_TOKEN }}`
 | `run-migration-audit` | Whether to run migration audit (`true`/`false`) | No | `false` |
 | `node-version` | Node.js version to use | No | `25` |
 | `base-url` | GitHub API base URL | No | `https://api.github.com` |
-| `ca-cert-path` | Path to CA certificate bundle (PEM) for TLS verification against GHES instances with internal or self-signed certificates | No | `""` |
+| `ca-cert` | CA certificate bundle content (PEM) for TLS verification against GHES. Use when the certificate is stored as a GitHub secret. | No | `""` |
+| `ca-cert-path` | Path to a CA certificate bundle file (PEM) on the runner. Use `ca-cert` instead when the certificate is stored as a secret. | No | `""` |
 | `retention-days` | Number of days to retain uploaded artifacts | No | `7` |
 | `batch-size` | Number of repositories per batch (enables batch processing for large organizations). Cannot be combined with `repository` — batch mode generates its own repo list. | No | `""` |
 | `batch-index` | Zero-based batch index (used with `batch-size` for parallel matrix jobs) | No | `""` |
@@ -165,6 +166,36 @@ To use with a GitHub Enterprise instance, set the `base-url` input to your GHE A
     repository: my-repo
     base-url: https://github.example.com/api/v3
 ```
+
+#### GHES with Custom CA Certificate
+
+For GHES instances that use an internal or self-signed CA certificate, provide the certificate so TLS verification works correctly. The recommended approach is to store the PEM content as a GitHub secret and pass it via the `ca-cert` input:
+
+```yaml
+- name: Gather Repository Stats (GHES with CA cert)
+  uses: mona-actions/gh-repo-stats-plus@v1
+  with:
+    github-token: ${{ github.token }}
+    access-token: ${{ secrets.GHES_TOKEN }}
+    organization: my-org
+    base-url: https://ghes.example.com/api/v3
+    ca-cert: ${{ secrets.GHES_CA_CERT }}
+```
+
+Alternatively, if the certificate file already exists on the runner (e.g., pre-installed or downloaded in an earlier step), use `ca-cert-path`:
+
+```yaml
+- name: Gather Repository Stats (GHES with CA cert file)
+  uses: mona-actions/gh-repo-stats-plus@v1
+  with:
+    github-token: ${{ github.token }}
+    access-token: ${{ secrets.GHES_TOKEN }}
+    organization: my-org
+    base-url: https://ghes.example.com/api/v3
+    ca-cert-path: /etc/ssl/certs/ghes-ca-bundle.pem
+```
+
+> **Note:** Specify either `ca-cert` or `ca-cert-path`, not both. When using `ca-cert`, the action automatically writes the content to a temporary file on the runner.
 
 ### Batch Processing (Organization)
 

--- a/action/README.md
+++ b/action/README.md
@@ -35,7 +35,7 @@ In both cases, the `github-token` input (typically `${{ secrets.GITHUB_TOKEN }}`
 | `run-migration-audit` | Whether to run migration audit (`true`/`false`) | No | `false` |
 | `node-version` | Node.js version to use | No | `25` |
 | `base-url` | GitHub API base URL | No | `https://api.github.com` |
-| `skip-tls-verification` | Skip TLS certificate verification for the target GitHub instance (use for GHES with self-signed certs or IP-based access) | No | `false` |
+| `ca-cert-path` | Path to CA certificate bundle (PEM) for TLS verification against GHES instances with internal or self-signed certificates | No | `""` |
 | `retention-days` | Number of days to retain uploaded artifacts | No | `7` |
 | `batch-size` | Number of repositories per batch (enables batch processing for large organizations). Cannot be combined with `repository` — batch mode generates its own repo list. | No | `""` |
 | `batch-index` | Zero-based batch index (used with `batch-size` for parallel matrix jobs) | No | `""` |

--- a/docs/commands/app-install-stats.md
+++ b/docs/commands/app-install-stats.md
@@ -27,6 +27,7 @@ gh repo-stats-plus app-install-stats [options]
 
 - `-u, --base-url <url>`: GitHub API base URL (Default: `https://api.github.com`)
 - `--proxy-url <url>`: Proxy URL if required
+- `--ca-cert <path>`: Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA, Env: `NODE_EXTRA_CA_CERTS`)
 - `--api-version <version>`: GitHub API version to use (`2022-11-28` or `2026-03-10`, Default: `2022-11-28`, Env: `GITHUB_API_VERSION`)
 - `--output-dir <dir>`: Output directory for generated files (Default: output)
 - `--output-file-name <name>`: Name for the primary output CSV file (default: auto-generated with timestamp)

--- a/docs/commands/codespace-stats.md
+++ b/docs/commands/codespace-stats.md
@@ -29,6 +29,7 @@ gh repo-stats-plus codespace-stats [options]
 
 - `-u, --base-url <url>`: GitHub API base URL (Default: `https://api.github.com`)
 - `--proxy-url <url>`: Proxy URL if required
+- `--ca-cert <path>`: Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA, Env: `NODE_EXTRA_CA_CERTS`)
 - `--api-version <version>`: GitHub API version to use (`2022-11-28` or `2026-03-10`, Default: `2022-11-28`, Env: `GITHUB_API_VERSION`)
 - `--output-dir <dir>`: Output directory for generated files (Default: output)
 - `--output-file-name <name>`: Name for the primary output CSV file (default: auto-generated with timestamp)

--- a/docs/commands/missing-repos.md
+++ b/docs/commands/missing-repos.md
@@ -17,6 +17,7 @@ gh repo-stats-plus missing-repos [options]
 - `-t, --access-token <token>`: GitHub access token
 - `-u, --base-url <url>`: GitHub API base URL (Default: `https://api.github.com`)
 - `--proxy-url <url>`: Proxy URL if required
+- `--ca-cert <path>`: Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA, Env: `NODE_EXTRA_CA_CERTS`)
 - `--api-version <version>`: GitHub API version to use (`2022-11-28` or `2026-03-10`, Default: `2022-11-28`, Env: `GITHUB_API_VERSION`)
 - `-v, --verbose`: Enable verbose logging
 

--- a/docs/commands/package-stats.md
+++ b/docs/commands/package-stats.md
@@ -31,6 +31,7 @@ gh repo-stats-plus package-stats [options]
 
 - `-u, --base-url <url>`: GitHub API base URL (Default: `https://api.github.com`)
 - `--proxy-url <url>`: Proxy URL if required
+- `--ca-cert <path>`: Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA, Env: `NODE_EXTRA_CA_CERTS`)
 - `--api-version <version>`: GitHub API version to use (`2022-11-28` or `2026-03-10`, Default: `2022-11-28`, Env: `GITHUB_API_VERSION`)
 - `--output-dir <dir>`: Output directory for generated files (Default: output)
 - `--output-file-name <name>`: Name for the primary output CSV file (default: auto-generated with timestamp)

--- a/docs/commands/project-stats.md
+++ b/docs/commands/project-stats.md
@@ -27,6 +27,7 @@ gh repo-stats-plus project-stats [options]
 
 - `-u, --base-url <url>`: GitHub API base URL (Default: `https://api.github.com`)
 - `--proxy-url <url>`: Proxy URL if required
+- `--ca-cert <path>`: Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA, Env: `NODE_EXTRA_CA_CERTS`)
 - `--api-version <version>`: GitHub API version to use (`2022-11-28` or `2026-03-10`, Default: `2022-11-28`, Env: `GITHUB_API_VERSION`)
 - `--output-dir <dir>`: Output directory for generated files (Default: output)
 - `-v, --verbose`: Enable verbose logging

--- a/docs/commands/repo-stats.md
+++ b/docs/commands/repo-stats.md
@@ -16,6 +16,7 @@ gh repo-stats-plus repo-stats [options]
 - `-t, --access-token <token>`: GitHub access token
 - `-u, --base-url <url>`: GitHub API base URL (Default: `https://api.github.com`)
 - `--proxy-url <url>`: Proxy URL if required
+- `--ca-cert <path>`: Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA, Env: `NODE_EXTRA_CA_CERTS`)
 - `--api-version <version>`: GitHub API version to use (`2022-11-28` or `2026-03-10`, Default: `2022-11-28`, Env: `GITHUB_API_VERSION`)
 - `-v, --verbose`: Enable verbose logging
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -54,7 +54,7 @@ The `github-token` input (typically `${{ github.token }}`) is always required fo
 
 ## GitHub Enterprise Support
 
-The action is compatible with GitHub Enterprise Server (GHES). Set the `base-url` input to your GHE API endpoint. For GHES instances with self-signed certificates, use `skip-tls-verification: "true"`.
+The action is compatible with GitHub Enterprise Server (GHES). Set the `base-url` input to your GHE API endpoint. For GHES instances with internal or self-signed certificates, provide the CA certificate bundle via `ca-cert-path`.
 
 If your GHE instance cannot reach github.com to download CLI extensions, provide `ghec-token` as well.
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -54,7 +54,18 @@ The `github-token` input (typically `${{ github.token }}`) is always required fo
 
 ## GitHub Enterprise Support
 
-The action is compatible with GitHub Enterprise Server (GHES). Set the `base-url` input to your GHE API endpoint. For GHES instances with internal or self-signed certificates, provide the CA certificate bundle via `ca-cert-path`.
+The action is compatible with GitHub Enterprise Server (GHES). Set the `base-url` input to your GHE API endpoint.
+
+For GHES instances with internal or self-signed CA certificates, provide the certificate via:
+
+- **`ca-cert`** — Pass the PEM content directly from a GitHub secret (recommended):
+  ```yaml
+  ca-cert: ${{ secrets.GHES_CA_CERT }}
+  ```
+- **`ca-cert-path`** — Point to a certificate file already on the runner:
+  ```yaml
+  ca-cert-path: /etc/ssl/certs/ghes-ca-bundle.pem
+  ```
 
 If your GHE instance cannot reach github.com to download CLI extensions, provide `ghec-token` as well.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -154,6 +154,26 @@ gh repo-stats-plus repo-stats \
 
 ## Working with Large Organizations
 
+### GitHub Enterprise Server (GHES)
+
+When connecting to a GHES instance with an internal or self-signed CA certificate, provide the CA certificate bundle so TLS verification works correctly:
+
+```bash
+gh repo-stats-plus repo-stats \
+  --org-name my-org \
+  --base-url https://ghes.example.com/api/v3 \
+  --ca-cert /path/to/ca-bundle.pem
+```
+
+Alternatively, set the `NODE_EXTRA_CA_CERTS` environment variable:
+
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/ca-bundle.pem
+gh repo-stats-plus repo-stats \
+  --org-name my-org \
+  --base-url https://ghes.example.com/api/v3
+```
+
 For organizations with many repositories, consider these best practices:
 
 ### Use Resume Capability

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -174,6 +174,18 @@ gh repo-stats-plus repo-stats \
   --base-url https://ghes.example.com/api/v3
 ```
 
+When using the GitHub Action, the recommended approach is to store the PEM content as a GitHub secret and pass it via the `ca-cert` input:
+
+```yaml
+- uses: mona-actions/gh-repo-stats-plus@v1
+  with:
+    github-token: ${{ github.token }}
+    access-token: ${{ secrets.GHES_TOKEN }}
+    organization: my-org
+    base-url: https://ghes.example.com/api/v3
+    ca-cert: ${{ secrets.GHES_CA_CERT }}
+```
+
 For organizations with many repositories, consider these best practices:
 
 ### Use Resume Capability

--- a/src/commands/app-install-stats-command.ts
+++ b/src/commands/app-install-stats-command.ts
@@ -66,6 +66,12 @@ appInstallStatsCommand
   )
   .addOption(
     new Option(
+      '--ca-cert <path>',
+      'Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA)',
+    ).env('NODE_EXTRA_CA_CERTS'),
+  )
+  .addOption(
+    new Option(
       '--api-version <version>',
       `GitHub API version to use (${VALID_API_VERSIONS.join(' or ')})`,
     )

--- a/src/commands/codespace-stats-command.ts
+++ b/src/commands/codespace-stats-command.ts
@@ -87,6 +87,12 @@ codespaceStatsCommand
   )
   .addOption(
     new Option(
+      '--ca-cert <path>',
+      'Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA)',
+    ).env('NODE_EXTRA_CA_CERTS'),
+  )
+  .addOption(
+    new Option(
       '--api-version <version>',
       `GitHub API version to use (${VALID_API_VERSIONS.join(' or ')})`,
     )

--- a/src/commands/missing-repos-command.ts
+++ b/src/commands/missing-repos-command.ts
@@ -44,6 +44,12 @@ missingReposCommand
   )
   .addOption(
     new Option(
+      '--ca-cert <path>',
+      'Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA)',
+    ).env('NODE_EXTRA_CA_CERTS'),
+  )
+  .addOption(
+    new Option(
       '--api-version <version>',
       `GitHub API version to use (${VALID_API_VERSIONS.join(' or ')})`,
     )

--- a/src/commands/package-stats-command.ts
+++ b/src/commands/package-stats-command.ts
@@ -110,6 +110,12 @@ packageStatsCommand
   )
   .addOption(
     new Option(
+      '--ca-cert <path>',
+      'Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA)',
+    ).env('NODE_EXTRA_CA_CERTS'),
+  )
+  .addOption(
+    new Option(
       '--api-version <version>',
       `GitHub API version to use (${VALID_API_VERSIONS.join(' or ')})`,
     )

--- a/src/commands/project-stats-command.ts
+++ b/src/commands/project-stats-command.ts
@@ -87,6 +87,12 @@ projectStatsCommand
   )
   .addOption(
     new Option(
+      '--ca-cert <path>',
+      'Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA)',
+    ).env('NODE_EXTRA_CA_CERTS'),
+  )
+  .addOption(
+    new Option(
       '--api-version <version>',
       `GitHub API version to use (${VALID_API_VERSIONS.join(' or ')})`,
     )

--- a/src/commands/repo-stats-command.ts
+++ b/src/commands/repo-stats-command.ts
@@ -87,6 +87,12 @@ repoStatsCommand
   )
   .addOption(
     new Option(
+      '--ca-cert <path>',
+      'Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA)',
+    ).env('NODE_EXTRA_CA_CERTS'),
+  )
+  .addOption(
+    new Option(
       '--api-version <version>',
       `GitHub API version to use (${VALID_API_VERSIONS.join(' or ')})`,
     )

--- a/src/init.ts
+++ b/src/init.ts
@@ -21,6 +21,7 @@ import {
   needsInstallationLookup,
   getAuthPrivateKey,
 } from './auth.js';
+import { loadCaCertificate } from './tls.js';
 import { StateManager } from './state.js';
 import { SessionManager } from './session.js';
 import { RetryConfig } from './retry.js';
@@ -48,6 +49,17 @@ export async function initCommand(
   logInitialization.start(logger);
 
   logInitialization.auth(logger);
+
+  const caCert = loadCaCertificate(opts.caCert, logger);
+
+  // Wrap createOctokit to bind the loaded CA cert for all callers
+  const createOctokitWithCa: typeof createOctokit = (
+    authConfig,
+    baseUrl,
+    proxyUrl,
+    logger,
+    fetch?,
+  ) => createOctokit(authConfig, baseUrl, proxyUrl, logger, fetch, caCert);
 
   const shouldLookupInstallation = needsInstallationLookup(opts);
 
@@ -81,7 +93,7 @@ export async function initCommand(
         org: orgsToProcess[0],
         baseUrl: opts.baseUrl,
         proxyUrl: opts.proxyUrl,
-        createOctokitFn: createOctokit,
+        createOctokitFn: createOctokitWithCa,
         logger,
       });
       logger.info(
@@ -106,7 +118,7 @@ export async function initCommand(
           org: orgName,
           baseUrl: opts.baseUrl,
           proxyUrl: opts.proxyUrl,
-          createOctokitFn: createOctokit,
+          createOctokitFn: createOctokitWithCa,
           logger,
         });
         logger.info(
@@ -117,7 +129,7 @@ export async function initCommand(
           appInstallationId: String(installationId),
         };
         const orgAuthConfig = createAuthConfig({ ...orgOpts, logger });
-        const orgOctokit = createOctokit(
+        const orgOctokit = createOctokitWithCa(
           orgAuthConfig,
           opts.baseUrl,
           opts.proxyUrl,
@@ -143,7 +155,7 @@ export async function initCommand(
       : createAuthConfig({ ...resolvedOpts, logger });
 
   logInitialization.octokit(logger);
-  const octokit = createOctokit(
+  const octokit = createOctokitWithCa(
     authConfig,
     opts.baseUrl,
     opts.proxyUrl,

--- a/src/init.ts
+++ b/src/init.ts
@@ -50,7 +50,7 @@ export async function initCommand(
 
   logInitialization.auth(logger);
 
-  const caCert = loadCaCertificate(opts.caCert, logger);
+  const caCert = loadCaCertificate(opts.caCertPath, logger);
 
   // Wrap createOctokit to bind the loaded CA cert for all callers
   const createOctokitWithCa: typeof createOctokit = (
@@ -58,8 +58,12 @@ export async function initCommand(
     baseUrl,
     proxyUrl,
     logger,
-    fetch?,
-  ) => createOctokit(authConfig, baseUrl, proxyUrl, logger, fetch, caCert);
+    options?,
+  ) =>
+    createOctokit(authConfig, baseUrl, proxyUrl, logger, {
+      ...options,
+      caCert,
+    });
 
   const shouldLookupInstallation = needsInstallationLookup(opts);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1163,14 +1163,15 @@ export async function checkForMissingRepos({
   const logger = await createLogger(opts.verbose, logFileName);
 
   const authConfig = createAuthConfig({ ...opts, logger: logger });
-  const caCert = loadCaCertificate(opts.caCert, logger);
+  const caCert = loadCaCertificate(opts.caCertPath, logger);
   const octokit = createOctokit(
     authConfig,
     opts.baseUrl,
     opts.proxyUrl,
     logger,
-    undefined,
-    caCert,
+    {
+      caCert,
+    },
   );
   const client = new OctokitClient(octokit);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { OctokitClient } from './service.js';
 import { createOctokit } from './octokit.js';
+import { loadCaCertificate } from './tls.js';
 import {
   Arguments,
   IssuesConnection,
@@ -1162,11 +1163,14 @@ export async function checkForMissingRepos({
   const logger = await createLogger(opts.verbose, logFileName);
 
   const authConfig = createAuthConfig({ ...opts, logger: logger });
+  const caCert = loadCaCertificate(opts.caCert, logger);
   const octokit = createOctokit(
     authConfig,
     opts.baseUrl,
     opts.proxyUrl,
     logger,
+    undefined,
+    caCert,
   );
   const client = new OctokitClient(octokit);
 

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -1,5 +1,6 @@
 import {
   fetch as undiciFetch,
+  Agent,
   ProxyAgent,
   RequestInfo as undiciRequestInfo,
   RequestInit as undiciRequestInit,
@@ -17,17 +18,41 @@ interface OnRateLimitOptions {
   url: string;
 }
 
+/**
+ * Builds a undici Dispatcher configured for the given proxy and/or CA
+ * certificate.  Returns `undefined` when neither is needed (default
+ * Node.js behaviour).
+ */
+const buildDispatcher = (
+  proxyUrl: string | undefined,
+  caCert: string | undefined,
+): Agent | ProxyAgent | undefined => {
+  if (proxyUrl && caCert) {
+    return new ProxyAgent({ uri: proxyUrl, requestTls: { ca: caCert } });
+  }
+  if (proxyUrl) {
+    return new ProxyAgent(proxyUrl);
+  }
+  if (caCert) {
+    return new Agent({ connect: { ca: caCert } });
+  }
+  return undefined;
+};
+
 export const createOctokit = (
   authConfig: AuthConfig,
   baseUrl: string,
   proxyUrl: string | undefined,
   logger: Logger,
   fetch?: any,
+  caCert?: string,
 ): Octokit => {
+  const dispatcher = buildDispatcher(proxyUrl, caCert);
+
   const customFetch = (url: undiciRequestInfo, options: undiciRequestInit) => {
     return undiciFetch(url, {
       ...options,
-      dispatcher: proxyUrl ? new ProxyAgent(proxyUrl) : undefined,
+      dispatcher,
     });
   };
 

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -39,19 +39,24 @@ const buildDispatcher = (
   return undefined;
 };
 
+export interface CreateOctokitOptions {
+  fetch?: any;
+  caCert?: string;
+}
+
 export const createOctokit = (
   authConfig: AuthConfig,
   baseUrl: string,
   proxyUrl: string | undefined,
   logger: Logger,
-  fetch?: any,
-  caCert?: string,
+  options?: CreateOctokitOptions,
 ): Octokit => {
+  const { fetch, caCert } = options ?? {};
   const dispatcher = buildDispatcher(proxyUrl, caCert);
 
-  const customFetch = (url: undiciRequestInfo, options: undiciRequestInit) => {
+  const customFetch = (url: undiciRequestInfo, opts: undiciRequestInit) => {
     return undiciFetch(url, {
-      ...options,
+      ...opts,
       dispatcher,
     });
   };

--- a/src/tls.ts
+++ b/src/tls.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'fs';
+import { Logger } from './types.js';
+
+/**
+ * Loads a CA certificate bundle (PEM format) for custom TLS verification.
+ *
+ * Resolution order:
+ * 1. Explicit path from `--ca-cert` CLI option
+ * 2. `NODE_EXTRA_CA_CERTS` environment variable
+ *
+ * @param caCertPath - Optional path to a PEM-encoded CA certificate file
+ * @param logger - Logger instance for diagnostic messages
+ * @returns The PEM content as a string, or undefined if no CA cert is configured
+ * @throws Error if the specified file cannot be read
+ */
+export const loadCaCertificate = (
+  caCertPath: string | undefined,
+  logger: Logger,
+): string | undefined => {
+  const resolvedPath = caCertPath || process.env.NODE_EXTRA_CA_CERTS;
+
+  if (!resolvedPath) {
+    return undefined;
+  }
+
+  const source = caCertPath ? '--ca-cert' : 'NODE_EXTRA_CA_CERTS';
+
+  try {
+    const cert = readFileSync(resolvedPath, 'utf-8');
+    logger.info(`Loaded CA certificate from ${source}: ${resolvedPath}`);
+    return cert;
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Unknown error reading file';
+    throw new Error(
+      `Failed to read CA certificate from ${source} (${resolvedPath}): ${message}`,
+      { cause: err },
+    );
+  }
+};

--- a/src/tls.ts
+++ b/src/tls.ts
@@ -28,13 +28,12 @@ export const loadCaCertificate = (
   try {
     const cert = readFileSync(resolvedPath, 'utf-8');
     logger.info(`Loaded CA certificate from ${source}`);
-    logger.debug(`CA certificate path: ${resolvedPath}`);
     return cert;
   } catch (err) {
     const message =
       err instanceof Error ? err.message : 'Unknown error reading file';
     throw new Error(
-      `Failed to read CA certificate from ${source} (${resolvedPath}): ${message}`,
+      `Failed to read CA certificate from ${source}: ${message}`,
       { cause: err },
     );
   }

--- a/src/tls.ts
+++ b/src/tls.ts
@@ -27,7 +27,8 @@ export const loadCaCertificate = (
 
   try {
     const cert = readFileSync(resolvedPath, 'utf-8');
-    logger.info(`Loaded CA certificate from ${source}: ${resolvedPath}`);
+    logger.info(`Loaded CA certificate from ${source}`);
+    logger.debug(`CA certificate path: ${resolvedPath}`);
     return cert;
   } catch (err) {
     const message =

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,9 @@ export interface Arguments {
   batchIndex?: number;
   batchDelay?: number;
 
+  // TLS
+  caCert?: string;
+
   // multi-org options
   delayBetweenOrgs?: number;
   continueOnError?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export interface Arguments {
   batchDelay?: number;
 
   // TLS
-  caCert?: string;
+  caCertPath?: string;
 
   // multi-org options
   delayBetweenOrgs?: number;


### PR DESCRIPTION
## Summary

Replace SSL bypass (`NODE_TLS_REJECT_UNAUTHORIZED=0`) with proper TLS verification using custom CA certificates. This addresses the review feedback from #177 that disabling SSL is not the right approach.

The implementation follows the pattern established in the handbook's `environment.ts`, using undici's `Agent` with `connect: { ca: caCert }` to verify TLS with a custom CA certificate instead of disabling verification entirely.

## Changes

### New: `src/tls.ts`
- `loadCaCertificate()` reads PEM content from `--ca-cert` path or `NODE_EXTRA_CA_CERTS` env var
- Clear error messages when files can't be read
- Preserves error cause chain for debugging

### Updated: `src/octokit.ts`
- New `buildDispatcher()` function handles all proxy + CA cert combinations:
  - Proxy + CA cert → `ProxyAgent({ uri, requestTls: { ca } })`
  - Proxy only → `ProxyAgent(uri)` (unchanged)
  - CA cert only → `Agent({ connect: { ca } })`
  - Neither → `undefined` (unchanged)
- `createOctokit()` accepts optional `caCert` parameter

### Updated: CLI commands
- `--ca-cert <path>` option added to all 6 commands (repo-stats, project-stats, app-install-stats, package-stats, codespace-stats, missing-repos)
- Env var: `NODE_EXTRA_CA_CERTS` (standard Node.js convention)

### Updated: `action.yml`
- Replaced `skip-tls-verification` input with `ca-cert-path`
- Removed `NODE_TLS_REJECT_UNAUTHORIZED=0` and all SSL bypass logic
- Validation steps use `curl --cacert` instead of `curl -k`
- CA cert path set via `NODE_EXTRA_CA_CERTS` env var for CLI consumption

### Tests
- New `__tests__/tls.test.ts` with 7 tests covering all paths
- Updated `__tests__/octokit.test.ts` with CA cert scenarios
- Updated `__tests__/commands.test.ts` to verify `--ca-cert` option

### Documentation
- Updated all 6 command reference docs with `--ca-cert` option
- Updated `docs/usage.md` with GHES CA cert examples
- Updated `docs/github-action.md` and `action/README.md`

## Usage

### CLI
```bash
gh repo-stats-plus repo-stats \
  --org-name my-org \
  --base-url https://ghes.example.com/api/v3 \
  --ca-cert /path/to/ca-bundle.pem
```

### Environment variable
```bash
export NODE_EXTRA_CA_CERTS=/path/to/ca-bundle.pem
gh repo-stats-plus repo-stats --org-name my-org --base-url https://ghes.example.com/api/v3
```

### GitHub Action
```yaml
- uses: mona-actions/gh-repo-stats-plus@v1
  with:
    organization: my-org
    base-url: https://ghes.example.com/api/v3
    ca-cert-path: /path/to/ca-bundle.pem
```

## Breaking Change

The `skip-tls-verification` input in `action.yml` has been replaced with `ca-cert-path`. Users who were bypassing TLS verification will need to provide their GHES CA certificate instead.

Closes #177