### PR TITLE
fix: remove secrets expression from ca-cert input description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ inputs:
     required: false
     default: "https://api.github.com"
   ca-cert:
-    description: "CA certificate bundle content (PEM) for TLS verification against GHES instances. Use this when the certificate is stored as a GitHub secret (e.g., ${{ secrets.GHES_CA_CERT }}). The action writes it to a temporary file automatically."
+    description: "CA certificate bundle content (PEM) for TLS verification against GHES instances. Pass the content of a GitHub secret (e.g., secrets.GHES_CA_CERT). The action writes it to a temporary file automatically."
     required: false
     default: ""
   ca-cert-path:


### PR DESCRIPTION
## Problem

The `ca-cert` input description in `action.yml` contains a literal `${{ secrets.GHES_CA_CERT }}` expression. GitHub Actions runners evaluate all `${{ }}` expressions in YAML, even inside description strings. Since composite actions don't have access to the `secrets` context, this causes a template validation error on GHES:

```
Error: mona-actions/gh-repo-stats-plus/.../action.yml (Line: 57, Col: 18):
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GHES_CA_CERT
```

## Fix

Removed the `${{ }}` wrapper from the description text so it reads as plain text rather than being interpreted as an expression.

**Before:**
> Use this when the certificate is stored as a GitHub secret (e.g., `${{ secrets.GHES_CA_CERT }}`).

**After:**
> Pass the content of a GitHub secret (e.g., `secrets.GHES_CA_CERT`).

Verified no other description fields in `action.yml` contain `${{ }}` expressions.