### PR TITLE
feat: add --batch-repo-list-file to skip redundant org repo pagination

### DIFF
--- a/__tests__/batch-processing.test.ts
+++ b/__tests__/batch-processing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createMockLogger } from './test-utils.js';
+import { existsSync, readFileSync } from 'fs';
 
 // Mock fs module
 vi.mock('fs');
@@ -213,6 +214,179 @@ describe('getRepoListForBatch', () => {
   });
 });
 
+describe('getRepoListForBatch with repoListFile', () => {
+  let logger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = createMockLogger();
+  });
+
+  it('should read repos from file and skip listOrgRepoNames', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      'test-org/alpha\ntest-org/bravo\ntest-org/charlie\n',
+    );
+    const client = createMockClient(['should-not-be-used']);
+
+    const result = await getRepoListForBatch({
+      client,
+      orgName: 'test-org',
+      batchSize: 2,
+      batchIndex: 0,
+      pageSize: 10,
+      logger,
+      repoListFile: '/tmp/repos.txt',
+    });
+
+    expect(result).toEqual(['test-org/alpha', 'test-org/bravo']);
+    expect(client.listOrgRepoNames).not.toHaveBeenCalled();
+  });
+
+  it('should slice the second batch from a file', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      'test-org/alpha\ntest-org/bravo\ntest-org/charlie\ntest-org/delta\n',
+    );
+    const client = createMockClient([]);
+
+    const result = await getRepoListForBatch({
+      client,
+      orgName: 'test-org',
+      batchSize: 2,
+      batchIndex: 1,
+      pageSize: 10,
+      logger,
+      repoListFile: '/tmp/repos.txt',
+    });
+
+    expect(result).toEqual(['test-org/charlie', 'test-org/delta']);
+  });
+
+  it('should accept bare repo names and prefix them with orgName', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('alpha\nbravo\ncharlie\n');
+    const client = createMockClient([]);
+
+    const result = await getRepoListForBatch({
+      client,
+      orgName: 'test-org',
+      batchSize: 10,
+      batchIndex: 0,
+      pageSize: 10,
+      logger,
+      repoListFile: '/tmp/repos.txt',
+    });
+
+    expect(result).toEqual([
+      'test-org/alpha',
+      'test-org/bravo',
+      'test-org/charlie',
+    ]);
+  });
+
+  it('should ignore blank lines and comments', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      '# header comment\ntest-org/alpha\n\n# spacer\ntest-org/bravo\n',
+    );
+    const client = createMockClient([]);
+
+    const result = await getRepoListForBatch({
+      client,
+      orgName: 'test-org',
+      batchSize: 10,
+      batchIndex: 0,
+      pageSize: 10,
+      logger,
+      repoListFile: '/tmp/repos.txt',
+    });
+
+    expect(result).toEqual(['test-org/alpha', 'test-org/bravo']);
+  });
+
+  it('should skip entries whose owner does not match orgName and warn', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      'test-org/alpha\nother-org/bravo\ntest-org/charlie\n',
+    );
+    const client = createMockClient([]);
+
+    const result = await getRepoListForBatch({
+      client,
+      orgName: 'test-org',
+      batchSize: 10,
+      batchIndex: 0,
+      pageSize: 10,
+      logger,
+      repoListFile: '/tmp/repos.txt',
+    });
+
+    expect(result).toEqual(['test-org/alpha', 'test-org/charlie']);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("does not match --org-name 'test-org'"),
+    );
+  });
+
+  it('should be case-insensitive on owner match', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('Test-Org/alpha\nTEST-ORG/bravo\n');
+    const client = createMockClient([]);
+
+    const result = await getRepoListForBatch({
+      client,
+      orgName: 'test-org',
+      batchSize: 10,
+      batchIndex: 0,
+      pageSize: 10,
+      logger,
+      repoListFile: '/tmp/repos.txt',
+    });
+
+    expect(result).toEqual(['Test-Org/alpha', 'TEST-ORG/bravo']);
+  });
+
+  it('should throw when the file does not exist', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    const client = createMockClient([]);
+
+    await expect(
+      getRepoListForBatch({
+        client,
+        orgName: 'test-org',
+        batchSize: 10,
+        batchIndex: 0,
+        pageSize: 10,
+        logger,
+        repoListFile: '/tmp/missing.txt',
+      }),
+    ).rejects.toThrow(/Batch repo list file not found/);
+  });
+
+  it('should warn on malformed entries and continue', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      'test-org/alpha\ntoo/many/slashes\n/empty-owner\nowner/\ntest-org/bravo\n',
+    );
+    const client = createMockClient([]);
+
+    const result = await getRepoListForBatch({
+      client,
+      orgName: 'test-org',
+      batchSize: 10,
+      batchIndex: 0,
+      pageSize: 10,
+      logger,
+      repoListFile: '/tmp/repos.txt',
+    });
+
+    expect(result).toEqual(['test-org/alpha', 'test-org/bravo']);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('malformed entry'),
+    );
+  });
+});
+
 describe('repo-stats-command batch options', () => {
   it('should have batch-size option defined', () => {
     const options = repoStatsCommand.options;
@@ -243,6 +417,18 @@ describe('repo-stats-command batch options', () => {
       (opt) => opt.long === '--batch-index',
     );
     expect(batchIndexOption?.envVar).toBe('BATCH_INDEX');
+  });
+
+  it('should have batch-repo-list-file option defined', () => {
+    const optionNames = repoStatsCommand.options.map((opt) => opt.long);
+    expect(optionNames).toContain('--batch-repo-list-file');
+  });
+
+  it('should map BATCH_REPO_LIST_FILE env var', () => {
+    const opt = repoStatsCommand.options.find(
+      (o) => o.long === '--batch-repo-list-file',
+    );
+    expect(opt?.envVar).toBe('BATCH_REPO_LIST_FILE');
   });
 });
 
@@ -294,5 +480,10 @@ describe('project-stats-command batch options', () => {
       (opt) => opt.long === '--batch-delay',
     );
     expect(batchDelayOption?.envVar).toBe('BATCH_DELAY');
+  });
+
+  it('should have batch-repo-list-file option defined', () => {
+    const optionNames = projectStatsCommand.options.map((opt) => opt.long);
+    expect(optionNames).toContain('--batch-repo-list-file');
   });
 });

--- a/__tests__/batch-processing.test.ts
+++ b/__tests__/batch-processing.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createMockLogger } from './test-utils.js';
-import { existsSync, readFileSync } from 'fs';
 
 // Mock fs module
 vi.mock('fs');
+
+import { existsSync, readFileSync } from 'fs';
 
 import { getRepoListForBatch } from '../src/main.js';
 import repoStatsCommand from '../src/commands/repo-stats-command.js';

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,10 @@ inputs:
     description: "Delay in seconds multiplied by batch index to stagger API requests and avoid rate limits"
     required: false
     default: ""
+  batch-repo-list-file:
+    description: "Path to a pre-fetched repository list file (one entry per line, 'owner/repo' or bare repo name). When provided alongside batch-size, batches read from this file instead of paginating the org's repos for every batch. Useful for large parallel matrix runs to avoid exhausting the GitHub App installation rate limit."
+    required: false
+    default: ""
   resume-from-last-save:
     description: "Resume from the last saved state. Automatically enabled when re-running failed jobs (run_attempt > 1). Downloads state artifact from a previous attempt and passes --resume-from-last-save to the CLI."
     required: false
@@ -474,6 +478,7 @@ runs:
         BATCH_SIZE: ${{ inputs.batch-size }}
         BATCH_INDEX: ${{ inputs.batch-index }}
         BATCH_DELAY: ${{ inputs.batch-delay }}
+        BATCH_REPO_LIST_FILE: ${{ inputs.batch-repo-list-file }}
         RESUME: ${{ steps.resolve-resume.outputs.resume }}
       run: |
         BATCH_ARGS=()
@@ -494,6 +499,17 @@ runs:
           BATCH_ARGS+=(--batch-delay "${BATCH_DELAY}")
         else
           unset BATCH_DELAY
+        fi
+        if [[ -n "${BATCH_REPO_LIST_FILE}" ]]; then
+          if [[ -z "${BATCH_SIZE}" ]]; then
+            echo "::error::batch-repo-list-file requires batch-size. Set the batch-size input or remove batch-repo-list-file."
+            exit 1
+          fi
+          if [[ ! -f "${BATCH_REPO_LIST_FILE}" ]]; then
+            echo "::error::batch-repo-list-file '${BATCH_REPO_LIST_FILE}' does not exist on the runner. Make sure the file is created (e.g. by a previous job + actions/download-artifact) before this step runs."
+            exit 1
+          fi
+          BATCH_ARGS+=(--batch-repo-list-file "${BATCH_REPO_LIST_FILE}")
         fi
 
         REPO_LIST_ARGS=()
@@ -542,6 +558,7 @@ runs:
         BATCH_SIZE: ${{ inputs.batch-size }}
         BATCH_INDEX: ${{ inputs.batch-index }}
         BATCH_DELAY: ${{ inputs.batch-delay }}
+        BATCH_REPO_LIST_FILE: ${{ inputs.batch-repo-list-file }}
         RESUME: ${{ steps.resolve-resume.outputs.resume }}
       run: |
         BATCH_ARGS=()
@@ -562,6 +579,17 @@ runs:
           BATCH_ARGS+=(--batch-delay "${BATCH_DELAY}")
         else
           unset BATCH_DELAY
+        fi
+        if [[ -n "${BATCH_REPO_LIST_FILE}" ]]; then
+          if [[ -z "${BATCH_SIZE}" ]]; then
+            echo "::error::batch-repo-list-file requires batch-size. Set the batch-size input or remove batch-repo-list-file."
+            exit 1
+          fi
+          if [[ ! -f "${BATCH_REPO_LIST_FILE}" ]]; then
+            echo "::error::batch-repo-list-file '${BATCH_REPO_LIST_FILE}' does not exist on the runner."
+            exit 1
+          fi
+          BATCH_ARGS+=(--batch-repo-list-file "${BATCH_REPO_LIST_FILE}")
         fi
 
         REPO_LIST_ARGS=()

--- a/docs/batch-processing.md
+++ b/docs/batch-processing.md
@@ -237,6 +237,80 @@ The same pattern works for `project-stats` — just swap the command:
 - **GitHub Actions matrix limit** is 256 jobs. At 50 repos/batch that covers up to 12,800 repos.
 - **Resume on failure**: Add `--resume-from-last-save` and cache/persist the state files between retries so a re-run picks up where it left off.
 - **`merge-multiple: true`** on `download-artifact` flattens all batch artifacts into a single directory, which is exactly what `combine-stats --files` expects.
+- **Avoid re-paginating the org list in every batch** — by default each batch independently calls `listOrgRepoNames` before slicing. With many parallel batches this can exhaust the GitHub App installation rate limit. Use `--batch-repo-list-file` (see below) to fetch the list once and have every batch reuse it.
+
+## Pre-fetched repo list (`--batch-repo-list-file`)
+
+For very large organizations (hundreds of batches), the redundant `listOrgRepoNames` call each batch makes can dominate the install's request budget. Fetch the list once in a setup job, upload it as an artifact, and have each matrix batch read from it:
+
+```yaml
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      total-batches: ${{ steps.calc.outputs.total }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install extension
+        run: gh extension install mona-actions/gh-repo-stats-plus
+        env:
+          GH_TOKEN: ${{ secrets.STATS_TOKEN }}
+      - name: Fetch org repo list once
+        env:
+          GH_TOKEN: ${{ secrets.STATS_TOKEN }}
+          ORG: ${{ inputs.org }}
+          BATCH_SIZE: ${{ inputs.batch-size }}
+        run: |
+          gh api graphql --paginate \
+            -f query='query($login: String!, $cursor: String) {
+              organization(login: $login) {
+                repositories(first: 100, after: $cursor) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes { nameWithOwner }
+                }
+              }
+            }' -F login="$ORG" \
+            --jq '.data.organization.repositories.nodes[].nameWithOwner' \
+            > repos.txt
+          echo "total=$(( ($(wc -l < repos.txt) + BATCH_SIZE - 1) / BATCH_SIZE ))" >> "$GITHUB_OUTPUT"
+      - id: calc
+        run: cat "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: org-repo-list
+          path: repos.txt
+
+  collect:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        batch-index: ${{ fromJson(needs.setup.outputs.total-batches) }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh extension install mona-actions/gh-repo-stats-plus
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: org-repo-list
+      - name: Collect stats (batch ${{ matrix.batch-index }})
+        env:
+          GH_TOKEN: ${{ secrets.STATS_TOKEN }}
+          ORG: ${{ inputs.org }}
+          BATCH_SIZE: ${{ inputs.batch-size }}
+        run: |
+          gh repo-stats-plus repo-stats \
+            --org-name "$ORG" \
+            --batch-size "$BATCH_SIZE" \
+            --batch-index ${{ matrix.batch-index }} \
+            --batch-repo-list-file repos.txt \
+            --output-dir output
+```
+
+File format: one entry per line, either `owner/repo` or a bare repo name (combined with `--org-name`). Blank lines and lines starting with `#` are ignored. Entries whose owner does not match `--org-name` are skipped with a warning.
 
 ## Using the GitHub Action
 

--- a/docs/batch-processing.md
+++ b/docs/batch-processing.md
@@ -248,7 +248,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      total-batches: ${{ steps.calc.outputs.total }}
+      matrix: ${{ steps.calc.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
       - name: Install extension
@@ -256,6 +256,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.STATS_TOKEN }}
       - name: Fetch org repo list once
+        id: calc
         env:
           GH_TOKEN: ${{ secrets.STATS_TOKEN }}
           ORG: ${{ inputs.org }}
@@ -272,9 +273,9 @@ jobs:
             }' -F login="$ORG" \
             --jq '.data.organization.repositories.nodes[].nameWithOwner' \
             > repos.txt
-          echo "total=$(( ($(wc -l < repos.txt) + BATCH_SIZE - 1) / BATCH_SIZE ))" >> "$GITHUB_OUTPUT"
-      - id: calc
-        run: cat "$GITHUB_OUTPUT"
+          TOTAL=$(( ($(wc -l < repos.txt) + BATCH_SIZE - 1) / BATCH_SIZE ))
+          INDICES=$(jq -nc "[range($TOTAL)]")
+          echo "matrix={\"batch-index\":$INDICES}" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@v4
         with:
           name: org-repo-list
@@ -286,8 +287,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 10
-      matrix:
-        batch-index: ${{ fromJson(needs.setup.outputs.total-batches) }}
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - run: gh extension install mona-actions/gh-repo-stats-plus

--- a/docs/commands/repo-stats.md
+++ b/docs/commands/repo-stats.md
@@ -53,8 +53,19 @@ gh repo-stats-plus repo-stats [options]
 - `--batch-size <size>`: Number of repositories per batch. Fetches the full repo list for the org and processes only the slice for the given batch index.
 - `--batch-index <index>`: Zero-based batch index to process (Default: 0). Requires `--batch-size`.
 - `--batch-delay <seconds>`: Stagger delay in seconds per batch index before starting (Default: 0). For example, with `--batch-delay 10`, batch 0 starts immediately, batch 1 waits 10s, batch 2 waits 20s, etc. Useful when launching multiple batches simultaneously to avoid API bursts.
+- `--batch-repo-list-file <file>`: Path to a pre-fetched repository list (one entry per line, `owner/repo` or bare repo name; `#` comments allowed). When provided, batches read from this file instead of paginating the org's repos for every batch. Requires `--batch-size`.
 
 Batch mode cannot be used with `--org-list` or `--repo-list`.
+
+#### When to use `--batch-repo-list-file`
+
+By default, every batch independently paginates the org's repository list before processing its slice. For large organizations split across many parallel matrix jobs, those redundant pagination calls multiply (`ceil(repo_count / page_size) × N batches`) and can quickly exhaust the GitHub App installation rate limit.
+
+Workflow that fetches the list once and reuses it across batches:
+
+1. A `setup` job fetches the org's repos once and writes them to `repos.txt`, then uploads it as an artifact.
+2. The matrix `collect` jobs each download the artifact and pass the file path via `--batch-repo-list-file`.
+3. Each batch reads from the file and slices to its `--batch-index`. No org-list pagination occurs in the matrix jobs.
 
 ## Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^22.19.0 || >=24"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/src/commands/project-stats-command.ts
+++ b/src/commands/project-stats-command.ts
@@ -48,6 +48,12 @@ function validate(opts: Arguments) {
       );
     }
   }
+
+  if (opts.batchRepoListFile && opts.batchSize == null) {
+    throw new Error(
+      '--batch-repo-list-file requires --batch-size. Use --repo-list instead if you want to process a flat list of repos without batching.',
+    );
+  }
 }
 
 const projectStatsCommand = new commander.Command();
@@ -265,6 +271,12 @@ projectStatsCommand
       .env('BATCH_DELAY')
       .default(0)
       .argParser(parseIntOption),
+  )
+  .addOption(
+    new Option(
+      '--batch-repo-list-file <file>',
+      "Path to a pre-fetched repository list (one entry per line, 'owner/repo' or bare repo name). When provided with --batch-size, batches read from this file instead of paginating the org's repos for every batch. Useful for large parallel matrix runs to avoid exhausting the installation rate limit.",
+    ).env('BATCH_REPO_LIST_FILE'),
   )
   .action(async (options: Arguments) => {
     console.log('Version:', VERSION);

--- a/src/commands/repo-stats-command.ts
+++ b/src/commands/repo-stats-command.ts
@@ -48,6 +48,12 @@ function validate(opts: Arguments) {
       );
     }
   }
+
+  if (opts.batchRepoListFile && opts.batchSize == null) {
+    throw new Error(
+      '--batch-repo-list-file requires --batch-size. Use --repo-list instead if you want to process a flat list of repos without batching.',
+    );
+  }
 }
 
 const repoStatsCommand = new commander.Command();
@@ -273,6 +279,12 @@ repoStatsCommand
       .env('BATCH_DELAY')
       .default(0)
       .argParser(parseIntOption),
+  )
+  .addOption(
+    new Option(
+      '--batch-repo-list-file <file>',
+      "Path to a pre-fetched repository list (one entry per line, 'owner/repo' or bare repo name). When provided with --batch-size, batches read from this file instead of paginating the org's repos for every batch. Useful for large parallel matrix runs to avoid exhausting the installation rate limit.",
+    ).env('BATCH_REPO_LIST_FILE'),
   )
   .action(async (options: Arguments) => {
     console.log('Version:', VERSION);

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'fs';
+import { resolve } from 'path';
 
 import { withRetry, RetryConfig } from './retry.js';
 import {
@@ -285,8 +286,16 @@ export function initializeCsvFile(fileName: string, logger: Logger): void {
 }
 
 /**
- * Fetches the full list of repository names for an organization using a
- * lightweight GraphQL query, then returns the slice for the requested batch.
+ * Returns the slice of an organization's repository list for the requested
+ * batch.
+ *
+ * By default, fetches the full list of repository names via a lightweight
+ * GraphQL query. When `repoListFile` is provided, reads the list from that
+ * file instead — useful for parallel matrix runs that would otherwise have
+ * every batch re-paginate the same org list and exhaust the installation
+ * rate limit. The file format is one entry per line, either bare repo
+ * names (combined with `orgName`) or `owner/repo` pairs; blank lines and
+ * lines starting with `#` are ignored.
  *
  * Logs the total repository count and batch count so users know how many
  * batches to run.
@@ -298,6 +307,7 @@ export async function getRepoListForBatch({
   batchIndex,
   pageSize,
   logger,
+  repoListFile,
 }: {
   client: Pick<OctokitClient, 'listOrgRepoNames'>;
   orgName: string;
@@ -305,14 +315,23 @@ export async function getRepoListForBatch({
   batchIndex: number;
   pageSize: number;
   logger: Logger;
+  repoListFile?: string;
 }): Promise<string[]> {
-  logger.info(
-    `Batch mode: fetching repository list for org '${orgName}' (batch size: ${batchSize}, batch index: ${batchIndex})`,
-  );
+  let allRepos: string[];
 
-  const allRepos: string[] = [];
-  for await (const repo of client.listOrgRepoNames(orgName, pageSize)) {
-    allRepos.push(`${repo.owner.login}/${repo.name}`);
+  if (repoListFile) {
+    logger.info(
+      `Batch mode: reading repository list from file '${repoListFile}' for org '${orgName}' (batch size: ${batchSize}, batch index: ${batchIndex})`,
+    );
+    allRepos = readRepoListFromFile(repoListFile, orgName, logger);
+  } else {
+    logger.info(
+      `Batch mode: fetching repository list for org '${orgName}' (batch size: ${batchSize}, batch index: ${batchIndex})`,
+    );
+    allRepos = [];
+    for await (const repo of client.listOrgRepoNames(orgName, pageSize)) {
+      allRepos.push(`${repo.owner.login}/${repo.name}`);
+    }
   }
 
   const totalRepos = allRepos.length;
@@ -345,6 +364,68 @@ export async function getRepoListForBatch({
   );
 
   return batchRepos;
+}
+
+/**
+ * Reads a repo list file and normalises every entry to `owner/repo` form.
+ * Each non-empty, non-comment line is either a bare repo name (combined
+ * with `orgName`) or already in `owner/repo` form. Entries that do not
+ * match `orgName` are dropped with a warning so a misplaced list cannot
+ * silently process the wrong organization.
+ */
+function readRepoListFromFile(
+  filePath: string,
+  orgName: string,
+  logger: Logger,
+): string[] {
+  const resolved = resolve(process.cwd(), filePath);
+  if (!existsSync(resolved)) {
+    throw new Error(`Batch repo list file not found: ${filePath}`);
+  }
+
+  const raw = readFileSync(resolved, 'utf-8');
+  const result: string[] = [];
+  let skipped = 0;
+
+  for (const rawLine of raw.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+
+    let owner: string;
+    let repo: string;
+    if (line.includes('/')) {
+      const parts = line.split('/');
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        logger.warn(
+          `Skipping malformed entry in repo list file: '${rawLine}' (expected 'owner/repo' or bare repo name)`,
+        );
+        skipped++;
+        continue;
+      }
+      [owner, repo] = parts;
+    } else {
+      owner = orgName;
+      repo = line;
+    }
+
+    if (owner.toLowerCase() !== orgName.toLowerCase()) {
+      logger.warn(
+        `Skipping entry '${rawLine}' from repo list file: owner '${owner}' does not match --org-name '${orgName}'`,
+      );
+      skipped++;
+      continue;
+    }
+
+    result.push(`${owner}/${repo}`);
+  }
+
+  if (skipped > 0) {
+    logger.warn(
+      `Skipped ${skipped} entr${skipped === 1 ? 'y' : 'ies'} from repo list file '${filePath}'`,
+    );
+  }
+
+  return result;
 }
 
 async function analyzeRepositoryStats({
@@ -609,6 +690,7 @@ async function processRepositories({
       batchIndex: opts.batchIndex ?? 0,
       pageSize: opts.pageSize || 10,
       logger,
+      repoListFile: opts.batchRepoListFile,
     });
 
     if (batchRepos.length === 0) {

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -162,6 +162,7 @@ async function processProjectStats({
       batchIndex: opts.batchIndex ?? 0,
       pageSize: opts.pageSize || 100,
       logger,
+      repoListFile: opts.batchRepoListFile,
     });
 
     if (batchRepos.length === 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,14 @@ export interface Arguments {
   batchSize?: number;
   batchIndex?: number;
   batchDelay?: number;
+  /**
+   * Optional path to a pre-fetched repository list (one entry per line,
+   * either bare repo name or `owner/repo`). When provided alongside
+   * `batchSize`, `getRepoListForBatch` reads from this file instead of
+   * paginating the org's repos via GraphQL — useful for large parallel
+   * matrix runs that would otherwise exhaust the installation rate limit.
+   */
+  batchRepoListFile?: string;
 
   // multi-org options
   delayBetweenOrgs?: number;


### PR DESCRIPTION
#Closes #191

When running many parallel batches against a large org, every batch independently calls listOrgRepoNames before slicing its window, which can dominate the GitHub App installation rate budget and lead to 'API rate limit exceeded' failures.

Add an optional --batch-repo-list-file <file> flag (and matching batch-repo-list-file action input) for repo-stats and project-stats. When set, the batch reads the pre-fetched repo list from disk instead of paginating the org. Callers can fetch the list once in a setup job, upload it as an artifact, and have every matrix batch reuse it.

- src/main.ts: refactor getRepoListForBatch to accept repoListFile and add readRepoListFromFile helper (supports owner/repo or bare names, ignores blanks/# comments, warns on owner mismatch).
- src/projects.ts: pass batchRepoListFile through.
- src/types.ts: add batchRepoListFile to Arguments.
- src/commands/{repo-stats,project-stats}-command.ts: register the new option, validate it requires --batch-size.
- action.yml: new batch-repo-list-file input wired through both gather steps with file-exists and batch-size validation.
- __tests__/batch-processing.test.ts: 10 new tests covering the read-from-file path and CLI option wiring.
- docs: document the option in commands/repo-stats.md and add a pre-fetched repo list example in batch-processing.md.

<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist

- [ ] Issue linked if existing
- [ ] Add a label to the pull request that indicates the type of change (e.g., `major`, `minor`, `patch`, `enhancement`, `bug`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests

## Additional Context

Add any other context or screenshots about the pull request here.
