### PR TITLE
fix: resolve batch-repo-list-file to absolute path before invoking CLI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -485,7 +485,11 @@ runs:
             echo "::error::batch-repo-list-file '${BATCH_REPO_LIST_FILE}' does not exist on the runner. Make sure the file is created (e.g. by a previous job + actions/download-artifact) before this step runs."
             exit 1
           fi
-          BATCH_ARGS+=(--batch-repo-list-file "${BATCH_REPO_LIST_FILE}")
+          # Resolve to absolute path so the CLI can find the file regardless
+          # of the working directory it ends up running in (gh extensions may
+          # change cwd to their install dir).
+          BATCH_REPO_LIST_FILE_ABS="$(cd "$(dirname "${BATCH_REPO_LIST_FILE}")" && pwd)/$(basename "${BATCH_REPO_LIST_FILE}")"
+          BATCH_ARGS+=(--batch-repo-list-file "${BATCH_REPO_LIST_FILE_ABS}")
         fi
 
         REPO_LIST_ARGS=()
@@ -565,7 +569,10 @@ runs:
             echo "::error::batch-repo-list-file '${BATCH_REPO_LIST_FILE}' does not exist on the runner."
             exit 1
           fi
-          BATCH_ARGS+=(--batch-repo-list-file "${BATCH_REPO_LIST_FILE}")
+          # Resolve to absolute path so the CLI can find the file regardless
+          # of the working directory it ends up running in.
+          BATCH_REPO_LIST_FILE_ABS="$(cd "$(dirname "${BATCH_REPO_LIST_FILE}")" && pwd)/$(basename "${BATCH_REPO_LIST_FILE}")"
+          BATCH_ARGS+=(--batch-repo-list-file "${BATCH_REPO_LIST_FILE_ABS}")
         fi
 
         REPO_LIST_ARGS=()


### PR DESCRIPTION
## Summary

When using a relative `batch-repo-list-file` input (e.g. `repos.txt` placed in `$GITHUB_WORKSPACE` by a prior `actions/download-artifact` step), the action's bash existence check passes — bash runs from `$GITHUB_WORKSPACE` — but the underlying CLI fails with:

```
Error: Batch repo list file not found: repos.txt
    at readRepoListFromFile (.../dist/index.js:6994:15)
```

## Root cause

[`readRepoListFromFile`](https://github.com/mona-actions/gh-repo-stats-plus/blob/main/src/main.ts) resolves the file via `resolve(process.cwd(), filePath)`. When the action invokes `gh repo-stats-plus` as a `gh` CLI extension, the Node process's effective cwd is not necessarily `$GITHUB_WORKSPACE` (it is typically the extension's install directory under `~/.local/share/gh/extensions/`). Relative paths therefore fail to resolve even though the file exists.

## Fix

Resolve the user-supplied path to an absolute path in the action shell step (right after the existence check) before passing `--batch-repo-list-file` to the CLI. Applied to both the repo-stats and project-stats steps.

This preserves the ergonomic relative-path UX (callers can still pass `repos.txt`) while making the lookup robust to whatever cwd the `gh` extension runtime chooses.

## Repro

Observed in a workflow that:

1. Downloads `repos.txt` via `actions/download-artifact` into `$GITHUB_WORKSPACE`.
2. Passes `batch-repo-list-file: repos.txt` to this action.
3. Fails with `Batch repo list file not found: repos.txt` after 3 retry attempts.

## Test plan

- Existing tests untouched (this is a shell-only change inside the action step).
- Verified the path-resolution snippet handles both relative (`repos.txt`) and already-absolute paths (`cd $(dirname /abs/path)` is a no-op for the directory portion).

## Related

Follow-up to #190 (which introduced `--batch-repo-list-file`).