### PR TITLE
feat: add org-repos command with batch matrix support

### DIFF
--- a/__tests__/org-repos-command.test.ts
+++ b/__tests__/org-repos-command.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import orgReposCommand from '../src/commands/org-repos-command.js';
+
+vi.mock('../src/org-repos.js', () => ({
+  runOrgRepos: vi.fn(),
+}));
+
+describe('org-repos-command', () => {
+  it('should have the correct name and description', () => {
+    expect(orgReposCommand.name()).toBe('org-repos');
+    expect(orgReposCommand.description()).toContain('Lists all repositories');
+  });
+
+  it('should have required options defined', () => {
+    const optionNames = orgReposCommand.options.map((o) => o.long);
+    expect(optionNames).toContain('--org-name');
+    expect(optionNames).toContain('--access-token');
+    expect(optionNames).toContain('--base-url');
+    expect(optionNames).toContain('--page-size');
+    expect(optionNames).toContain('--output-dir');
+    expect(optionNames).toContain('--output-file-name');
+    expect(optionNames).toContain('--batch-size');
+    expect(optionNames).toContain('--max-batches');
+    expect(optionNames).toContain('--ca-cert');
+    expect(optionNames).toContain('--verbose');
+  });
+
+  it('should have correct defaults', () => {
+    const baseUrl = orgReposCommand.options.find(
+      (o) => o.long === '--base-url',
+    );
+    expect(baseUrl?.defaultValue).toBe('https://api.github.com');
+
+    const pageSize = orgReposCommand.options.find(
+      (o) => o.long === '--page-size',
+    );
+    expect(pageSize?.defaultValue).toBe(100);
+    expect(typeof pageSize?.defaultValue).toBe('number');
+
+    const outputDir = orgReposCommand.options.find(
+      (o) => o.long === '--output-dir',
+    );
+    expect(outputDir?.defaultValue).toBe('output');
+
+    const maxBatches = orgReposCommand.options.find(
+      (o) => o.long === '--max-batches',
+    );
+    expect(maxBatches?.defaultValue).toBe(256);
+    expect(typeof maxBatches?.defaultValue).toBe('number');
+  });
+
+  it('should have correct env var mappings', () => {
+    const envMappings = [
+      { long: '--org-name', env: 'ORG_NAME' },
+      { long: '--access-token', env: 'ACCESS_TOKEN' },
+      { long: '--base-url', env: 'BASE_URL' },
+      { long: '--page-size', env: 'PAGE_SIZE' },
+      { long: '--output-dir', env: 'OUTPUT_DIR' },
+      { long: '--batch-size', env: 'BATCH_SIZE' },
+      { long: '--max-batches', env: 'MAX_BATCHES' },
+    ];
+
+    for (const { long, env } of envMappings) {
+      const option = orgReposCommand.options.find((o) => o.long === long);
+      expect(option?.envVar, `${long} env var`).toBe(env);
+    }
+  });
+
+  it('should parse numeric options as numbers', () => {
+    orgReposCommand.parseOptions(['-o', 'test-org', '-t', 'test-token']);
+    const opts = orgReposCommand.opts();
+    expect(opts.pageSize).toBeTypeOf('number');
+    expect(opts.maxBatches).toBeTypeOf('number');
+  });
+
+  it('should be a valid commander command', () => {
+    expect(typeof orgReposCommand.parse).toBe('function');
+    expect(typeof orgReposCommand.parseAsync).toBe('function');
+  });
+});

--- a/__tests__/org-repos.test.ts
+++ b/__tests__/org-repos.test.ts
@@ -56,6 +56,18 @@ describe('calculateBatchMatrix', () => {
     expect(matrix['batch-index']).toEqual([0]);
   });
 
+  it('throws when requestedBatchSize is less than 1', () => {
+    expect(() => calculateBatchMatrix([], 0, 256)).toThrow(
+      'requestedBatchSize must be >= 1',
+    );
+  });
+
+  it('throws when maxBatches is less than 1', () => {
+    expect(() => calculateBatchMatrix([], 10, 0)).toThrow(
+      'maxBatches must be >= 1',
+    );
+  });
+
   it('handles an empty repo list', () => {
     const { totalBatches, matrix } = calculateBatchMatrix([], 10, 256);
     expect(totalBatches).toBe(0);

--- a/__tests__/org-repos.test.ts
+++ b/__tests__/org-repos.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { calculateBatchMatrix, fetchOrgRepos } from '../src/org-repos.js';
+import { createMockLogger } from './test-utils.js';
+
+vi.mock('fs');
+vi.mock('../src/utils.js', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/utils.js')>();
+  return {
+    ...mod,
+    resolveOutputPath: vi.fn(
+      async (_dir: string, fileName: string) => `/output/${fileName}`,
+    ),
+  };
+});
+
+import { writeFileSync } from 'fs';
+
+function makeClient(repos: { name: string; owner: { login: string } }[]) {
+  return {
+    listOrgRepoNames: vi.fn().mockImplementation(async function* () {
+      for (const repo of repos) yield repo;
+    }),
+  } as Pick<import('../src/service.js').OctokitClient, 'listOrgRepoNames'>;
+}
+
+describe('calculateBatchMatrix', () => {
+  it('returns correct indices for an exact division', () => {
+    const repos = Array.from({ length: 10 }, (_, i) => `org/repo-${i}`);
+    const { batchSize, totalBatches, matrix } = calculateBatchMatrix(
+      repos,
+      5,
+      256,
+    );
+    expect(totalBatches).toBe(2);
+    expect(batchSize).toBe(5);
+    expect(matrix['batch-index']).toEqual([0, 1]);
+  });
+
+  it('rounds up when repos do not divide evenly', () => {
+    const repos = Array.from({ length: 11 }, (_, i) => `org/repo-${i}`);
+    const { totalBatches } = calculateBatchMatrix(repos, 5, 256);
+    expect(totalBatches).toBe(3);
+  });
+
+  it('adjusts batch size when totalBatches would exceed maxBatches', () => {
+    const repos = Array.from({ length: 1000 }, (_, i) => `org/repo-${i}`);
+    const { batchSize, totalBatches } = calculateBatchMatrix(repos, 1, 10);
+    expect(totalBatches).toBeLessThanOrEqual(10);
+    expect(batchSize).toBeGreaterThan(1);
+  });
+
+  it('returns a single batch for repos <= batchSize', () => {
+    const repos = Array.from({ length: 3 }, (_, i) => `org/repo-${i}`);
+    const { totalBatches, matrix } = calculateBatchMatrix(repos, 10, 256);
+    expect(totalBatches).toBe(1);
+    expect(matrix['batch-index']).toEqual([0]);
+  });
+
+  it('handles an empty repo list', () => {
+    const { totalBatches, matrix } = calculateBatchMatrix([], 10, 256);
+    expect(totalBatches).toBe(0);
+    expect(matrix['batch-index']).toEqual([]);
+  });
+});
+
+describe('fetchOrgRepos', () => {
+  let logger: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = createMockLogger();
+  });
+
+  it('returns all repos as owner/repo strings', async () => {
+    const client = makeClient([
+      { name: 'alpha', owner: { login: 'my-org' } },
+      { name: 'beta', owner: { login: 'my-org' } },
+    ]);
+
+    const result = await fetchOrgRepos({
+      orgName: 'my-org',
+      opts: { pageSize: 100 },
+      client,
+      logger,
+    });
+
+    expect(result.repos).toEqual(['my-org/alpha', 'my-org/beta']);
+    expect(result.repoCount).toBe(2);
+    expect(result.outputFile).toBeUndefined();
+    expect(result.matrix).toBeUndefined();
+  });
+
+  it('writes repos to file when outputFileName is provided', async () => {
+    const client = makeClient([{ name: 'alpha', owner: { login: 'my-org' } }]);
+
+    const result = await fetchOrgRepos({
+      orgName: 'my-org',
+      opts: { pageSize: 100, outputFileName: 'repos.txt', outputDir: 'output' },
+      client,
+      logger,
+    });
+
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('repos.txt'),
+      'my-org/alpha\n',
+      'utf-8',
+    );
+    expect(result.outputFile).toBeDefined();
+  });
+
+  it('calculates batch matrix when batchSize is provided', async () => {
+    const repos = Array.from({ length: 10 }, (_, i) => ({
+      name: `repo-${i}`,
+      owner: { login: 'my-org' },
+    }));
+    const client = makeClient(repos);
+
+    const result = await fetchOrgRepos({
+      orgName: 'my-org',
+      opts: { pageSize: 100, batchSize: 3, maxBatches: 256 },
+      client,
+      logger,
+    });
+
+    expect(result.matrix).toBeDefined();
+    expect(result.totalBatches).toBe(4); // ceil(10/3)
+    expect(result.batchSize).toBe(3);
+    expect(result.matrix!['batch-index']).toEqual([0, 1, 2, 3]);
+  });
+
+  it('respects maxBatches limit', async () => {
+    const repos = Array.from({ length: 100 }, (_, i) => ({
+      name: `repo-${i}`,
+      owner: { login: 'my-org' },
+    }));
+    const client = makeClient(repos);
+
+    const result = await fetchOrgRepos({
+      orgName: 'my-org',
+      opts: { pageSize: 100, batchSize: 1, maxBatches: 5 },
+      client,
+      logger,
+    });
+
+    expect(result.totalBatches).toBeLessThanOrEqual(5);
+  });
+
+  it('handles an org with no repos', async () => {
+    const client = makeClient([]);
+
+    const result = await fetchOrgRepos({
+      orgName: 'empty-org',
+      opts: { pageSize: 100 },
+      client,
+      logger,
+    });
+
+    expect(result.repos).toEqual([]);
+    expect(result.repoCount).toBe(0);
+  });
+});

--- a/src/commands/org-repos-command.ts
+++ b/src/commands/org-repos-command.ts
@@ -1,0 +1,165 @@
+import * as commander from 'commander';
+import {
+  parseIntOption,
+  parseApiVersionOption,
+  generateOrgReposFileName,
+  resolveOutputPath,
+} from '../utils.js';
+import { DEFAULT_API_VERSION, VALID_API_VERSIONS } from '../service.js';
+import { Arguments } from '../types.js';
+import VERSION from '../version.js';
+import { runOrgRepos } from '../org-repos.js';
+
+const { Option } = commander;
+
+function validate(opts: Arguments): void {
+  if (!opts.orgName) {
+    throw new Error('--org-name (-o) is required');
+  }
+
+  if (opts.batchSize != null && opts.batchSize < 1) {
+    throw new Error('--batch-size must be at least 1');
+  }
+
+  if (opts.maxBatches != null && opts.maxBatches < 1) {
+    throw new Error('--max-batches must be at least 1');
+  }
+}
+
+const orgReposCommand = new commander.Command();
+
+orgReposCommand
+  .name('org-repos')
+  .description(
+    'Lists all repositories for an organization. Optionally writes the list to a file and outputs a batch matrix for parallel processing.',
+  )
+  .version(VERSION)
+  .addOption(
+    new Option('-o, --org-name <org>', 'The name of the organization').env(
+      'ORG_NAME',
+    ),
+  )
+  .addOption(
+    new Option('-t, --access-token <token>', 'GitHub access token').env(
+      'ACCESS_TOKEN',
+    ),
+  )
+  .addOption(
+    new Option('-u, --base-url <url>', 'GitHub API base URL')
+      .env('BASE_URL')
+      .default('https://api.github.com'),
+  )
+  .addOption(
+    new Option('--proxy-url <url>', 'Proxy URL if required').env('PROXY_URL'),
+  )
+  .addOption(
+    new Option(
+      '--ca-cert <path>',
+      'Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA)',
+    ).env('NODE_EXTRA_CA_CERTS'),
+  )
+  .addOption(
+    new Option(
+      '--api-version <version>',
+      `GitHub API version to use (${VALID_API_VERSIONS.join(' or ')})`,
+    )
+      .env('GITHUB_API_VERSION')
+      .default(DEFAULT_API_VERSION)
+      .argParser(parseApiVersionOption),
+  )
+  .addOption(
+    new Option('-v, --verbose', 'Enable verbose logging').env('VERBOSE'),
+  )
+  .addOption(new Option('--app-id <id>', 'GitHub App ID').env('APP_ID'))
+  .addOption(
+    new Option('--private-key <key>', 'GitHub App private key').env(
+      'PRIVATE_KEY',
+    ),
+  )
+  .addOption(
+    new Option(
+      '--private-key-file <file>',
+      'Path to GitHub App private key file',
+    ).env('PRIVATE_KEY_FILE'),
+  )
+  .addOption(
+    new Option('--app-installation-id <id>', 'GitHub App installation ID').env(
+      'APP_INSTALLATION_ID',
+    ),
+  )
+  .addOption(
+    new Option('--page-size <size>', 'Number of repos per API page')
+      .env('PAGE_SIZE')
+      .default(100)
+      .argParser(parseIntOption),
+  )
+  .addOption(
+    new Option('--output-dir <dir>', 'Output directory for generated files')
+      .env('OUTPUT_DIR')
+      .default('output'),
+  )
+  .addOption(
+    new Option(
+      '--output-file-name <name>',
+      'Name for the output file containing the repo list (one owner/repo per line). Defaults to an auto-generated timestamped filename when --save-repo-list is set.',
+    ).env('OUTPUT_FILE_NAME'),
+  )
+  .addOption(
+    new Option(
+      '--save-repo-list [value]',
+      'Write the full repo list to a file in the output directory',
+    ).env('SAVE_REPO_LIST'),
+  )
+  .addOption(
+    new Option(
+      '--batch-size <size>',
+      'When provided, calculates a batch matrix splitting repos into chunks of this size. Outputs batch-index array, total batches, and adjusted batch size.',
+    )
+      .env('BATCH_SIZE')
+      .argParser(parseIntOption),
+  )
+  .addOption(
+    new Option(
+      '--max-batches <count>',
+      'Maximum number of batches allowed when using --batch-size (default: 256). If the computed batch count exceeds this limit, batch-size is automatically increased.',
+    )
+      .env('MAX_BATCHES')
+      .default(256)
+      .argParser(parseIntOption),
+  )
+  .action(async (options: Arguments & { saveRepoList?: boolean | string }) => {
+    console.log('Version:', VERSION);
+
+    validate(options);
+
+    // Resolve output file name when saving is requested
+    if (options.saveRepoList && !options.outputFileName) {
+      options.outputFileName = await resolveOutputPath(
+        options.outputDir,
+        generateOrgReposFileName(options.orgName!),
+      );
+    }
+
+    const result = await runOrgRepos(options);
+
+    // Print the repo list to stdout
+    for (const repo of result.repos) {
+      console.log(repo);
+    }
+
+    if (result.outputFile) {
+      console.log(
+        `\n✅ Wrote ${result.repoCount} repos to ${result.outputFile}`,
+      );
+    }
+
+    if (result.matrix) {
+      console.log(`\n📊 Batch matrix:`);
+      console.log(`   Repos:         ${result.repoCount}`);
+      console.log(`   Batch size:    ${result.batchSize}`);
+      console.log(`   Total batches: ${result.totalBatches}`);
+      console.log(`   Matrix:        ${JSON.stringify(result.matrix)}`);
+    }
+  });
+
+export default orgReposCommand;

--- a/src/commands/org-repos-command.ts
+++ b/src/commands/org-repos-command.ts
@@ -1,6 +1,7 @@
 import * as commander from 'commander';
 import {
   parseIntOption,
+  parseBooleanOption,
   parseApiVersionOption,
   generateOrgReposFileName,
   resolveOutputPath,
@@ -108,7 +109,9 @@ orgReposCommand
     new Option(
       '--save-repo-list [value]',
       'Write the full repo list to a file in the output directory',
-    ).env('SAVE_REPO_LIST'),
+    )
+      .env('SAVE_REPO_LIST')
+      .argParser(parseBooleanOption),
   )
   .addOption(
     new Option(
@@ -148,17 +151,15 @@ orgReposCommand
     }
 
     if (result.outputFile) {
-      console.log(
-        `\n✅ Wrote ${result.repoCount} repos to ${result.outputFile}`,
-      );
+      console.log(`\nWrote ${result.repoCount} repos to ${result.outputFile}`);
     }
 
     if (result.matrix) {
-      console.log(`\n📊 Batch matrix:`);
-      console.log(`   Repos:         ${result.repoCount}`);
-      console.log(`   Batch size:    ${result.batchSize}`);
-      console.log(`   Total batches: ${result.totalBatches}`);
-      console.log(`   Matrix:        ${JSON.stringify(result.matrix)}`);
+      console.log(`\nBatch matrix:`);
+      console.log(`  Repos:         ${result.repoCount}`);
+      console.log(`  Batch size:    ${result.batchSize}`);
+      console.log(`  Total batches: ${result.totalBatches}`);
+      console.log(`  Matrix:        ${JSON.stringify(result.matrix)}`);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import codespaceStatsCommand from './commands/codespace-stats-command.js';
 import combineStatsCommand from './commands/combine-stats-command.js';
 import postProcessCommand from './commands/post-process-command.js';
 import rowsToColumnsCommand from './commands/rows-to-columns-command.js';
+import orgReposCommand from './commands/org-repos-command.js';
 
 const program = new commander.Command();
 
@@ -29,6 +30,7 @@ program
   .addCommand(codespaceStatsCommand)
   .addCommand(combineStatsCommand)
   .addCommand(postProcessCommand)
-  .addCommand(rowsToColumnsCommand);
+  .addCommand(rowsToColumnsCommand)
+  .addCommand(orgReposCommand);
 
 program.parse(process.argv);

--- a/src/init.ts
+++ b/src/init.ts
@@ -490,3 +490,33 @@ function logSummary(
     );
   }
 }
+
+/**
+ * Creates a logger and OctokitClient from command options.
+ *
+ * Lightweight alternative to initCommand for commands that only need a GitHub
+ * API client without the full processing pipeline (state management, CSV
+ * output, multi-org loops, etc.).
+ */
+export async function createClientFromOpts(
+  opts: Arguments,
+  logFileName: string,
+): Promise<{ logger: Logger; client: OctokitClient }> {
+  const logger = await createLogger(opts.verbose, logFileName);
+  const caCert = loadCaCertificate(opts.caCertPath, logger);
+  const authConfig = createAuthConfig({ ...opts, logger });
+  const octokit = createOctokit(
+    authConfig,
+    opts.baseUrl,
+    opts.proxyUrl,
+    logger,
+    {
+      caCert,
+    },
+  );
+  const client = new OctokitClient(
+    octokit,
+    opts.apiVersion ?? DEFAULT_API_VERSION,
+  );
+  return { logger, client };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,4 @@
 import { OctokitClient } from './service.js';
-import { createOctokit } from './octokit.js';
-import { loadCaCertificate } from './tls.js';
 import {
   Arguments,
   IssuesConnection,
@@ -15,8 +13,6 @@ import {
   OrgContext,
   CommandConfig,
 } from './types.js';
-import { createLogger } from './logger.js';
-import { createAuthConfig } from './auth.js';
 import { StateManager } from './state.js';
 import {
   appendFileSync,
@@ -43,7 +39,7 @@ import {
   readCsvFile,
   REPO_STATS_COLUMNS,
 } from './csv.js';
-import { initCommand, executeCommand } from './init.js';
+import { initCommand, executeCommand, createClientFromOpts } from './init.js';
 
 // --- Command configuration ---
 
@@ -1238,24 +1234,10 @@ export async function checkForMissingRepos({
 }): Promise<{
   missingRepos: string[];
 }> {
-  // Initialize only what we need - logger and client
   const logFileName = `${opts.orgName!}-missing-repos-check-${
     new Date().toISOString().split('T')[0]
   }.log`;
-  const logger = await createLogger(opts.verbose, logFileName);
-
-  const authConfig = createAuthConfig({ ...opts, logger: logger });
-  const caCert = loadCaCertificate(opts.caCertPath, logger);
-  const octokit = createOctokit(
-    authConfig,
-    opts.baseUrl,
-    opts.proxyUrl,
-    logger,
-    {
-      caCert,
-    },
-  );
-  const client = new OctokitClient(octokit);
+  const { logger, client } = await createClientFromOpts(opts, logFileName);
 
   const org = opts.orgName!.toLowerCase();
   const per_page = opts.pageSize || 10;

--- a/src/org-repos.ts
+++ b/src/org-repos.ts
@@ -1,0 +1,141 @@
+import { OctokitClient, DEFAULT_API_VERSION } from './service.js';
+import { createOctokit } from './octokit.js';
+import { loadCaCertificate } from './tls.js';
+import { Arguments, Logger } from './types.js';
+import { createLogger } from './logger.js';
+import { createAuthConfig } from './auth.js';
+import { writeFileSync } from 'fs';
+import { generateOrgReposFileName, resolveOutputPath } from './utils.js';
+
+export interface BatchMatrix {
+  'batch-index': number[];
+}
+
+export interface OrgReposResult {
+  repos: string[];
+  repoCount: number;
+  outputFile?: string;
+  batchSize?: number;
+  totalBatches?: number;
+  matrix?: BatchMatrix;
+}
+
+/**
+ * Calculates a batch matrix from a list of repos, respecting the maxBatches limit.
+ * If the natural number of batches exceeds maxBatches, the batch size is adjusted upward.
+ */
+export function calculateBatchMatrix(
+  repos: string[],
+  requestedBatchSize: number,
+  maxBatches: number,
+): { batchSize: number; totalBatches: number; matrix: BatchMatrix } {
+  let batchSize = requestedBatchSize;
+  let totalBatches = Math.ceil(repos.length / batchSize);
+
+  if (totalBatches > maxBatches) {
+    batchSize = Math.ceil(repos.length / maxBatches);
+    totalBatches = Math.ceil(repos.length / batchSize);
+  }
+
+  const matrix: BatchMatrix = {
+    'batch-index': Array.from({ length: totalBatches }, (_, i) => i),
+  };
+
+  return { batchSize, totalBatches, matrix };
+}
+
+/**
+ * Lists all repositories for an organization and optionally writes them to a
+ * file and/or calculates a batch matrix.
+ */
+export async function runOrgRepos(opts: Arguments): Promise<OrgReposResult> {
+  const orgName = opts.orgName;
+  if (!orgName) {
+    throw new Error('orgName is required');
+  }
+
+  const logFileName = `${orgName}-org-repos-${
+    new Date().toISOString().split('T')[0]
+  }.log`;
+  const logger = await createLogger(opts.verbose, logFileName);
+
+  const caCert = loadCaCertificate(opts.caCertPath, logger);
+  const authConfig = createAuthConfig({ ...opts, logger });
+  const octokit = createOctokit(
+    authConfig,
+    opts.baseUrl,
+    opts.proxyUrl,
+    logger,
+    {
+      caCert,
+    },
+  );
+  const client = new OctokitClient(
+    octokit,
+    opts.apiVersion ?? DEFAULT_API_VERSION,
+  );
+
+  return fetchOrgRepos({ orgName, opts, client, logger });
+}
+
+/**
+ * Core fetch logic — separated so it can be unit tested with a mock client.
+ */
+export async function fetchOrgRepos({
+  orgName,
+  opts,
+  client,
+  logger,
+}: {
+  orgName: string;
+  opts: Pick<
+    Arguments,
+    'pageSize' | 'outputFileName' | 'outputDir' | 'batchSize' | 'maxBatches'
+  >;
+  client: Pick<OctokitClient, 'listOrgRepoNames'>;
+  logger: Logger;
+}): Promise<OrgReposResult> {
+  const pageSize = opts.pageSize ?? 100;
+
+  logger.info(`Fetching repos for organization: ${orgName}`);
+
+  const repos: string[] = [];
+  for await (const repo of client.listOrgRepoNames(orgName, pageSize)) {
+    const fullName = `${repo.owner.login}/${repo.name}`;
+    repos.push(fullName);
+    logger.debug(`Found repo: ${fullName}`);
+  }
+
+  logger.info(`Total repos found: ${repos.length}`);
+
+  const result: OrgReposResult = { repos, repoCount: repos.length };
+
+  if (opts.outputFileName) {
+    const fileName = opts.outputFileName.includes('/')
+      ? opts.outputFileName
+      : await resolveOutputPath(
+          opts.outputDir,
+          opts.outputFileName || generateOrgReposFileName(orgName),
+        );
+    writeFileSync(fileName, repos.join('\n') + '\n', 'utf-8');
+    result.outputFile = fileName;
+    logger.info(`Wrote ${repos.length} repos to ${fileName}`);
+  }
+
+  if (opts.batchSize != null) {
+    const maxBatches = opts.maxBatches ?? 256;
+    const { batchSize, totalBatches, matrix } = calculateBatchMatrix(
+      repos,
+      opts.batchSize,
+      maxBatches,
+    );
+    result.batchSize = batchSize;
+    result.totalBatches = totalBatches;
+    result.matrix = matrix;
+    logger.info(
+      `Batch matrix: ${repos.length} repos → ${totalBatches} batches of ~${batchSize}`,
+    );
+  }
+
+  return result;
+}

--- a/src/org-repos.ts
+++ b/src/org-repos.ts
@@ -2,6 +2,7 @@ import { OctokitClient } from './service.js';
 import { Arguments, Logger } from './types.js';
 import { createClientFromOpts } from './init.js';
 import { writeFileSync } from 'fs';
+import { isAbsolute } from 'path';
 import { generateOrgReposFileName, resolveOutputPath } from './utils.js';
 
 export interface BatchMatrix {
@@ -26,6 +27,15 @@ export function calculateBatchMatrix(
   requestedBatchSize: number,
   maxBatches: number,
 ): { batchSize: number; totalBatches: number; matrix: BatchMatrix } {
+  if (requestedBatchSize < 1) {
+    throw new Error(
+      `requestedBatchSize must be >= 1, got ${requestedBatchSize}`,
+    );
+  }
+  if (maxBatches < 1) {
+    throw new Error(`maxBatches must be >= 1, got ${maxBatches}`);
+  }
+
   let batchSize = requestedBatchSize;
   let totalBatches = Math.ceil(repos.length / batchSize);
 
@@ -92,7 +102,7 @@ export async function fetchOrgRepos({
   const result: OrgReposResult = { repos, repoCount: repos.length };
 
   if (opts.outputFileName) {
-    const fileName = opts.outputFileName.includes('/')
+    const fileName = isAbsolute(opts.outputFileName)
       ? opts.outputFileName
       : await resolveOutputPath(
           opts.outputDir,

--- a/src/org-repos.ts
+++ b/src/org-repos.ts
@@ -1,9 +1,6 @@
-import { OctokitClient, DEFAULT_API_VERSION } from './service.js';
-import { createOctokit } from './octokit.js';
-import { loadCaCertificate } from './tls.js';
+import { OctokitClient } from './service.js';
 import { Arguments, Logger } from './types.js';
-import { createLogger } from './logger.js';
-import { createAuthConfig } from './auth.js';
+import { createClientFromOpts } from './init.js';
 import { writeFileSync } from 'fs';
 import { generateOrgReposFileName, resolveOutputPath } from './utils.js';
 
@@ -57,23 +54,7 @@ export async function runOrgRepos(opts: Arguments): Promise<OrgReposResult> {
   const logFileName = `${orgName}-org-repos-${
     new Date().toISOString().split('T')[0]
   }.log`;
-  const logger = await createLogger(opts.verbose, logFileName);
-
-  const caCert = loadCaCertificate(opts.caCertPath, logger);
-  const authConfig = createAuthConfig({ ...opts, logger });
-  const octokit = createOctokit(
-    authConfig,
-    opts.baseUrl,
-    opts.proxyUrl,
-    logger,
-    {
-      caCert,
-    },
-  );
-  const client = new OctokitClient(
-    octokit,
-    opts.apiVersion ?? DEFAULT_API_VERSION,
-  );
+  const { logger, client } = await createClientFromOpts(opts, logFileName);
 
   return fetchOrgRepos({ orgName, opts, client, logger });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,9 @@ export interface Arguments {
 
   // GitHub API version
   apiVersion?: string;
+
+  // org-repos options
+  maxBatches?: number;
 }
 
 export type AuthResponse = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,11 @@ export function generatePackageStatsFileName(orgName: string): string {
   return `${orgName.toLowerCase()}-package-stats-${timestamp}_ts.csv`;
 }
 
+export function generateOrgReposFileName(orgName: string): string {
+  const timestamp = generateTimestamp();
+  return `${orgName.toLowerCase()}-repos-${timestamp}.txt`;
+}
+
 /**
  * Converts kilobytes to megabytes
  * @param kb Size in kilobytes, can be null or undefined


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

Closes #194 

Adds a new `org-repos` command that lists all repositories for a GitHub organization and optionally writes the list to a file and/or computes a batch matrix for parallel processing pipelines -- replacing the ad-hoc `index.mjs` script with a proper CLI subcommand that reuses existing authenticated client infrastructure.

The command reuses `OctokitClient.listOrgRepoNames` (GraphQL paginator) to stream repos incrementally, avoiding large REST payloads. When `--batch-size` is supplied, `calculateBatchMatrix()` splits repos into chunks and automatically adjusts the batch size upward if the number of batches would exceed `--max-batches` (default 256), matching the logic from the reference `index.mjs`.

**Key design decisions:**

- `src/org-repos.ts` separates the core `fetchOrgRepos()` logic (accepts a mock-friendly `client` + `logger`) from `runOrgRepos()` (the full entry point that wires up auth/client from `Arguments`). This keeps unit tests simple without needing a live Octokit.
- The repeated logger + auth + caCert + OctokitClient wiring that existed in both `checkForMissingRepos` (main.ts) and the new command was extracted into a shared `createClientFromOpts()` helper in `init.ts`, eliminating the duplication.
- `maxBatches` is added to the `Arguments` type so it flows through the standard options pipeline.
- `generateOrgReposFileName()` is added to `utils.ts` for auto-named timestamped output files.

**Usage examples:**

```bash
# List repos to stdout
gh repo-stats-plus org-repos -o my-org -t $TOKEN

# Save to file
gh repo-stats-plus org-repos -o my-org -t $TOKEN --save-repo-list

# Compute batch matrix (e.g. for a GitHub Actions matrix job)
gh repo-stats-plus org-repos -o my-org -t $TOKEN --batch-size 50 --max-batches 256
```

## Checklist

- [ ] Issue linked if existing
- [ ] Add a label to the pull request that indicates the type of change (e.g., `major`, `minor`, `patch`, `enhancement`, `bug`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

New files: `src/org-repos.ts`, `src/commands/org-repos-command.ts`, `__tests__/org-repos.test.ts`, `__tests__/org-repos-command.test.ts`. All 626 tests pass; lint, format, and type-check are clean.