### PR TITLE
docs: add org-repos command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ This TypeScript rewrite offers several advantages:
 
 16. **Codespace Stats**: Retrieve codespace usage statistics for organizations, including machine details (CPU, memory, storage), ownership information, and lifecycle timestamps. Based on [scottluskcis/gh-data-fetch](https://github.com/scottluskcis/gh-data-fetch). See the [Codespace Stats Command Reference](docs/commands/codespace-stats.md).
 
+17. **Org Repos Listing with Batch Matrix**: List all repositories in an organization, optionally write the list to a file, and calculate a batch matrix for parallel GitHub Actions matrix jobs. Supports `--max-batches` to cap the number of batches and automatically adjust batch size. See the [Org Repos Command Reference](docs/commands/org-repos.md).
+
 ## Technical Implementation
 
 The extension is built using modern TypeScript patterns with:
@@ -110,6 +112,7 @@ See the [GitHub Action documentation](action/README.md) for full inputs/outputs 
 | [Rows-to-Columns](docs/commands/rows-to-columns.md) | Pivot additional CSV rows into columns        |
 | [Package Stats](docs/commands/package-stats.md)     | Retrieve package statistics for organizations |
 | [Codespace Stats](docs/commands/codespace-stats.md) | Retrieve codespace usage for organizations    |
+| [Org Repos](docs/commands/org-repos.md)             | List org repos and generate a batch matrix    |
 
 ## Common Usage Examples
 
@@ -209,6 +212,30 @@ gh repo-stats-plus missing-repos \
 # Auto-process missing repositories
 gh repo-stats-plus repo-stats --org-name my-org --auto-process-missing
 ```
+
+### Org Repos and Batch Matrix
+
+List all repos for an organization and optionally generate a batch matrix for parallel GitHub Actions jobs:
+
+```bash
+# Print all repos to stdout
+gh repo-stats-plus org-repos --org-name my-org
+
+# Save the list to a file
+gh repo-stats-plus org-repos --org-name my-org --save-repo-list
+
+# Generate a batch matrix (50 repos per batch) — useful as a setup job
+gh repo-stats-plus org-repos --org-name my-org --batch-size 50
+
+# Save repo list and generate matrix together, capping at 20 batches
+gh repo-stats-plus org-repos \
+  --org-name my-org \
+  --batch-size 50 \
+  --max-batches 20 \
+  --save-repo-list
+```
+
+See the [Org Repos Command Reference](docs/commands/org-repos.md) for the full GitHub Actions matrix workflow example.
 
 ### Batch Processing
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -82,7 +82,8 @@ Use `org-repos` as a setup job to fetch the full repo list once and calculate th
 gh repo-stats-plus org-repos \
   --org-name myorg \
   --batch-size 50 \
-  --save-repo-list
+  --save-repo-list \
+  --output-file-name myorg-org-repos.txt
 
 # Then run repo-stats for each batch index from the matrix output
 gh repo-stats-plus repo-stats \

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,7 @@ This page provides an overview of all available commands. See the individual com
 | [app-install-stats](commands/app-install-stats.md) | Retrieve GitHub App installation statistics for an organization (PAT only)     |
 | [package-stats](commands/package-stats.md)         | Retrieve package statistics (Maven, npm, etc.) for an organization             |
 | [codespace-stats](commands/codespace-stats.md)     | Retrieve codespace usage statistics for an organization                        |
+| [org-repos](commands/org-repos.md)                 | List all repositories in an organization and optionally build a batch matrix   |
 | [combine-stats](commands/combine-stats.md)         | Merge multiple CSV output files into a single combined report                  |
 | [post-process](commands/post-process.md)           | Transform CSV data using configurable rules for pattern matching and cleanup   |
 | [rows-to-columns](commands/rows-to-columns.md)     | Pivot rows from an additional CSV into columns in a base CSV                   |
@@ -40,6 +41,12 @@ gh repo-stats-plus package-stats --org-name my-org --package-type NPM
 # Collect codespace usage statistics
 gh repo-stats-plus codespace-stats --org-name my-org
 
+# List all repos in an organization
+gh repo-stats-plus org-repos --org-name my-org
+
+# List repos and generate a batch matrix (e.g., for GitHub Actions)
+gh repo-stats-plus org-repos --org-name my-org --batch-size 50
+
 # Combine multiple CSV files
 gh repo-stats-plus combine-stats --files file1.csv file2.csv
 
@@ -65,6 +72,27 @@ All of these commands can also be run via the [GitHub Action](github-action.md) 
 ---
 
 ## Common Workflows
+
+### Batch Matrix Setup
+
+Use `org-repos` as a setup job to fetch the full repo list once and calculate the batch matrix for parallel GitHub Actions matrix jobs:
+
+```bash
+# Fetch all repos and generate a batch matrix (50 repos per batch)
+gh repo-stats-plus org-repos \
+  --org-name myorg \
+  --batch-size 50 \
+  --save-repo-list
+
+# Then run repo-stats for each batch index from the matrix output
+gh repo-stats-plus repo-stats \
+  --org-name myorg \
+  --batch-size 50 \
+  --batch-index 0 \
+  --batch-repo-list-file output/myorg-org-repos.txt
+```
+
+See the [org-repos Command Reference](commands/org-repos.md) and the [Batch Processing Guide](batch-processing.md) for complete GitHub Actions workflow examples.
 
 ### Complete Organization Analysis
 

--- a/docs/commands/org-repos.md
+++ b/docs/commands/org-repos.md
@@ -1,0 +1,183 @@
+# org-repos Command
+
+Lists all repositories for an organization. Optionally writes the list to a file and outputs a batch matrix for parallel processing (e.g., GitHub Actions matrix strategy).
+
+## Basic Syntax
+
+```bash
+gh repo-stats-plus org-repos [options]
+```
+
+## Options
+
+### Core Options
+
+- `-o, --org-name <org>`: The name of the organization (Required, Env: `ORG_NAME`)
+- `-t, --access-token <token>`: GitHub access token (Env: `ACCESS_TOKEN`)
+- `-u, --base-url <url>`: GitHub API base URL (Default: `https://api.github.com`, Env: `BASE_URL`)
+- `--proxy-url <url>`: Proxy URL if required (Env: `PROXY_URL`)
+- `--ca-cert <path>`: Path to CA certificate bundle (PEM) for TLS verification (e.g. GHES with internal CA, Env: `NODE_EXTRA_CA_CERTS`)
+- `--api-version <version>`: GitHub API version to use (`2022-11-28` or `2026-03-10`, Default: `2022-11-28`, Env: `GITHUB_API_VERSION`)
+- `-v, --verbose`: Enable verbose logging (Env: `VERBOSE`)
+
+### GitHub App Authentication
+
+- `--app-id <id>`: GitHub App ID (Env: `APP_ID`)
+- `--private-key <key>`: GitHub App private key content (Env: `PRIVATE_KEY`)
+- `--private-key-file <file>`: Path to GitHub App private key file (Env: `PRIVATE_KEY_FILE`)
+- `--app-installation-id <id>`: GitHub App installation ID (optional — automatically looked up if omitted, Env: `APP_INSTALLATION_ID`)
+
+### Performance
+
+- `--page-size <size>`: Number of repos per API page (Default: 100, Env: `PAGE_SIZE`)
+
+### Output
+
+- `--output-dir <dir>`: Output directory for generated files (Default: `output`, Env: `OUTPUT_DIR`)
+- `--output-file-name <name>`: Name for the output file containing the repo list (one `owner/repo` per line). Defaults to an auto-generated timestamped filename when `--save-repo-list` is set. (Env: `OUTPUT_FILE_NAME`)
+- `--save-repo-list [value]`: Write the full repo list to a file in the output directory (Env: `SAVE_REPO_LIST`)
+
+### Batch Matrix
+
+- `--batch-size <size>`: When provided, calculates a batch matrix splitting repos into chunks of this size. Outputs a `batch-index` array, total batch count, and the effective batch size. (Env: `BATCH_SIZE`)
+- `--max-batches <count>`: Maximum number of batches allowed when using `--batch-size` (Default: 256). If the computed batch count would exceed this limit, the batch size is automatically increased to stay within it. (Env: `MAX_BATCHES`)
+
+## Examples
+
+### List All Repos
+
+Print all repositories in an organization to stdout (one `owner/repo` per line):
+
+```bash
+gh repo-stats-plus org-repos --org-name my-org
+```
+
+### Save Repo List to File
+
+Write the repo list to a file (auto-generated timestamped name) in the default output directory:
+
+```bash
+gh repo-stats-plus org-repos --org-name my-org --save-repo-list
+```
+
+Specify a custom file name:
+
+```bash
+gh repo-stats-plus org-repos \
+  --org-name my-org \
+  --output-file-name repos.txt \
+  --output-dir ./my-output
+```
+
+### Generate a Batch Matrix
+
+Calculate how many batches are needed for a given batch size and print the matrix:
+
+```bash
+gh repo-stats-plus org-repos --org-name my-org --batch-size 50
+```
+
+Sample output for an org with 120 repos:
+
+```
+my-org/repo-1
+my-org/repo-2
+...
+
+Batch matrix:
+  Repos:         120
+  Batch size:    50
+  Total batches: 3
+  Matrix:        {"batch-index":[0,1,2]}
+```
+
+### Limit Maximum Number of Batches
+
+Cap the number of batches to 10, automatically adjusting batch size upward:
+
+```bash
+gh repo-stats-plus org-repos \
+  --org-name my-org \
+  --batch-size 10 \
+  --max-batches 10
+```
+
+### Save Repo List and Generate Matrix Together
+
+```bash
+gh repo-stats-plus org-repos \
+  --org-name my-org \
+  --save-repo-list \
+  --batch-size 100
+```
+
+### GitHub Enterprise Server
+
+```bash
+gh repo-stats-plus org-repos \
+  --org-name my-org \
+  --base-url https://ghes.example.com/api/v3 \
+  --ca-cert /path/to/ca-bundle.pem
+```
+
+## Using the Batch Matrix with GitHub Actions
+
+The `org-repos` command is designed to work as a **setup job** in a GitHub Actions matrix workflow. It fetches the full repo list once and produces the `batch-index` array used to fan out parallel `repo-stats` jobs.
+
+### Example Workflow
+
+```yaml
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.org-repos.outputs.matrix }}
+      batch-size: ${{ steps.org-repos.outputs.batch-size }}
+    steps:
+      - name: Get org repos and build matrix
+        id: org-repos
+        uses: mona-actions/gh-repo-stats-plus@v1
+        with:
+          command: org-repos
+          organization: my-org
+          batch-size: 50
+          save-repo-list: true
+          github-token: ${{ github.token }}
+
+      - name: Upload repo list artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-list
+          path: output/*.txt
+
+  collect:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    steps:
+      - name: Download repo list
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-list
+          path: output/
+
+      - name: Run repo-stats for batch
+        uses: mona-actions/gh-repo-stats-plus@v1
+        with:
+          command: repo-stats
+          organization: my-org
+          batch-size: ${{ needs.setup.outputs.batch-size }}
+          batch-index: ${{ matrix.batch-index }}
+          batch-repo-list-file: output/my-org-org-repos.txt
+          github-token: ${{ github.token }}
+```
+
+See the [Batch Processing Guide](../batch-processing.md) for complete workflow examples.
+
+## Output
+
+- Prints all repositories to **stdout** (one `owner/repo` per line) in every case.
+- When `--save-repo-list` or `--output-file-name` is set, also writes the list to a file.
+- When `--batch-size` is set, prints a batch matrix summary to stdout with the `batch-index` array, total batch count, and effective batch size.
+- Log files are written to the `logs/` directory.

--- a/docs/commands/org-repos.md
+++ b/docs/commands/org-repos.md
@@ -108,6 +108,7 @@ gh repo-stats-plus org-repos \
 gh repo-stats-plus org-repos \
   --org-name my-org \
   --save-repo-list \
+  --output-file-name my-org-org-repos.txt \
   --batch-size 100
 ```
 
@@ -137,6 +138,8 @@ jobs:
       - name: Get org repos and build matrix
         id: org-repos
         uses: mona-actions/gh-repo-stats-plus@v1
+        env:
+          OUTPUT_FILE_NAME: my-org-org-repos.txt
         with:
           command: org-repos
           organization: my-org

--- a/docs/commands/org-repos.md
+++ b/docs/commands/org-repos.md
@@ -135,23 +135,15 @@ jobs:
       matrix: ${{ steps.org-repos.outputs.matrix }}
       batch-size: ${{ steps.org-repos.outputs.batch-size }}
     steps:
+      - uses: actions/checkout@v4
       - name: Get org repos and build matrix
         id: org-repos
         uses: mona-actions/gh-repo-stats-plus@v1
-        env:
-          OUTPUT_FILE_NAME: my-org-org-repos.txt
         with:
-          command: org-repos
+          type: org-repos
           organization: my-org
           batch-size: 50
-          save-repo-list: true
           github-token: ${{ github.token }}
-
-      - name: Upload repo list artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: repo-list
-          path: output/*.txt
 
   collect:
     needs: setup
@@ -159,20 +151,14 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
-      - name: Download repo list
-        uses: actions/download-artifact@v4
-        with:
-          name: repo-list
-          path: output/
-
+      - uses: actions/checkout@v4
       - name: Run repo-stats for batch
         uses: mona-actions/gh-repo-stats-plus@v1
         with:
-          command: repo-stats
+          type: organization
           organization: my-org
           batch-size: ${{ needs.setup.outputs.batch-size }}
           batch-index: ${{ matrix.batch-index }}
-          batch-repo-list-file: output/my-org-org-repos.txt
           github-token: ${{ github.token }}
 ```
 


### PR DESCRIPTION
PR #193 added the `org-repos` command but the documentation was not updated at that time. This PR fills that gap.

## What's added

- **`docs/commands/org-repos.md`** -- New dedicated reference page covering all CLI options (core, auth, output, batch matrix), usage examples (list repos, save to file, generate matrix, cap max batches, GHES), and a full GitHub Actions matrix workflow showing how `org-repos` works as a setup job that feeds `--batch-repo-list-file` into parallel `repo-stats` matrix jobs.

- **`docs/commands.md`** -- Added `org-repos` to the commands table, quick start examples, and a new "Batch Matrix Setup" workflow section in Common Workflows.

- **`README.md`** -- Added item 17 to the Key Features list, a row to the Documentation table linking to the new page, and an "Org Repos and Batch Matrix" usage example section.

## Notes

No code changes -- documentation only. All existing behavior is unchanged.