### PR TITLE
feat: add org-repos type to action for batch matrix setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -167,15 +167,15 @@ outputs:
   matrix:
     description: "JSON matrix object for strategy.matrix (contains batch-index array). Only set when type is 'org-repos' and batch-size is provided."
     value: ${{ steps.org-repos.outputs.matrix }}
-  batch_size:
+  batch-size:
     description: "Effective batch size (may be increased if repo count exceeds max-batches). Only set when type is 'org-repos' and batch-size is provided."
-    value: ${{ steps.org-repos.outputs.batch_size }}
-  repo_count:
+    value: ${{ steps.org-repos.outputs.batch-size }}
+  repo-count:
     description: "Total number of repositories found. Only set when type is 'org-repos'."
-    value: ${{ steps.org-repos.outputs.repo_count }}
+    value: ${{ steps.org-repos.outputs.repo-count }}
   repo-list-file:
     description: "Absolute path to the repo list file written by org-repos (one owner/repo per line). Only set when type is 'org-repos'."
-    value: ${{ steps.org-repos.outputs.repo_list_file }}
+    value: ${{ steps.org-repos.outputs.repo-list-file }}
 
 runs:
   using: "composite"
@@ -435,19 +435,47 @@ runs:
           ORG_REPOS_ARGS+=(--batch-size "${BATCH_SIZE}")
         fi
 
-        OUTPUT=$(gh repo-stats-plus org-repos "${ORG_REPOS_ARGS[@]}")
+        ORG_REPOS_STDOUT_FILE="$(mktemp)"
+        trap 'rm -f "${ORG_REPOS_STDOUT_FILE}"' EXIT
 
-        # Extract repo count from stdout
-        REPO_COUNT=$(echo "${OUTPUT}" | grep -c '/' || echo "0")
-        echo "repo_count=${REPO_COUNT}" >> "$GITHUB_OUTPUT"
-        echo "repo_list_file=${{ github.workspace }}/repos.txt" >> "$GITHUB_OUTPUT"
+        gh repo-stats-plus org-repos "${ORG_REPOS_ARGS[@]}" > "${ORG_REPOS_STDOUT_FILE}"
+
+        # Count repositories from the written repo list file instead of stdout,
+        # because stdout may contain non-repository lines with '/' characters.
+        REPO_LIST_FILE="${{ github.workspace }}/repos.txt"
+        if [[ -f "${REPO_LIST_FILE}" ]]; then
+          REPO_COUNT=$(wc -l < "${REPO_LIST_FILE}")
+        else
+          REPO_COUNT=0
+        fi
+        echo "repo-count=${REPO_COUNT}" >> "$GITHUB_OUTPUT"
+        echo "repo-list-file=${REPO_LIST_FILE}" >> "$GITHUB_OUTPUT"
 
         # If batch-size was provided, parse the matrix from CLI output
         if [[ -n "${BATCH_SIZE}" ]]; then
-          MATRIX_LINE=$(echo "${OUTPUT}" | grep '  Matrix:' | sed 's/.*Matrix: *//')
-          BATCH_SIZE_LINE=$(echo "${OUTPUT}" | grep '  Batch size:' | sed 's/.*Batch size: *//')
+          MATRIX_RAW_LINE=$(grep -m 1 '  Matrix:' "${ORG_REPOS_STDOUT_FILE}" || true)
+          BATCH_SIZE_RAW_LINE=$(grep -m 1 '  Batch size:' "${ORG_REPOS_STDOUT_FILE}" || true)
+
+          if [[ -z "${MATRIX_RAW_LINE}" ]] || [[ -z "${BATCH_SIZE_RAW_LINE}" ]]; then
+            echo "::error::Failed to parse matrix or batch size from gh repo-stats-plus org-repos output. The CLI output format may have changed."
+            exit 1
+          fi
+
+          MATRIX_LINE=$(echo "${MATRIX_RAW_LINE}" | sed 's/.*Matrix: *//')
+          BATCH_SIZE_LINE=$(echo "${BATCH_SIZE_RAW_LINE}" | sed 's/.*Batch size: *//')
+
+          if [[ -z "${MATRIX_LINE}" ]] || [[ -z "${BATCH_SIZE_LINE}" ]]; then
+            echo "::error::Parsed matrix or batch size was empty. Raw matrix line: '${MATRIX_RAW_LINE}'. Raw batch size line: '${BATCH_SIZE_RAW_LINE}'."
+            exit 1
+          fi
+
+          [[ "${BATCH_SIZE_LINE}" =~ ^[0-9]+$ ]] && [[ "${BATCH_SIZE_LINE}" -ge 1 ]] || {
+            echo "::error::Parsed batch size '${BATCH_SIZE_LINE}' is invalid."
+            exit 1
+          }
+
           echo "matrix=${MATRIX_LINE}" >> "$GITHUB_OUTPUT"
-          echo "batch_size=${BATCH_SIZE_LINE}" >> "$GITHUB_OUTPUT"
+          echo "batch-size=${BATCH_SIZE_LINE}" >> "$GITHUB_OUTPUT"
           echo "✅ Batch matrix computed: ${REPO_COUNT} repos"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   type:
-    description: "Type of stats gathering: 'repository', 'organization', 'project-stats', 'app-install-stats', 'package-stats', 'codespace-stats', 'migration-audit', or 'combine'"
+    description: "Type of stats gathering: 'repository', 'organization', 'project-stats', 'app-install-stats', 'package-stats', 'codespace-stats', 'migration-audit', 'org-repos', or 'combine'"
     required: false
     default: "repository"
   github-token:
@@ -164,6 +164,18 @@ outputs:
   artifact-id:
     description: "ID of the uploaded artifact containing the stats"
     value: ${{ steps.upload-artifact.outputs.artifact-id }}
+  matrix:
+    description: "JSON matrix object for strategy.matrix (contains batch-index array). Only set when type is 'org-repos' and batch-size is provided."
+    value: ${{ steps.org-repos.outputs.matrix }}
+  batch_size:
+    description: "Effective batch size (may be increased if repo count exceeds max-batches). Only set when type is 'org-repos' and batch-size is provided."
+    value: ${{ steps.org-repos.outputs.batch_size }}
+  repo_count:
+    description: "Total number of repositories found. Only set when type is 'org-repos'."
+    value: ${{ steps.org-repos.outputs.repo_count }}
+  repo-list-file:
+    description: "Absolute path to the repo list file written by org-repos (one owner/repo per line). Only set when type is 'org-repos'."
+    value: ${{ steps.org-repos.outputs.repo_list_file }}
 
 runs:
   using: "composite"
@@ -183,11 +195,11 @@ runs:
         INPUT_TYPE: ${{ inputs.type }}
       run: |
         case "${INPUT_TYPE}" in
-          repository|organization|project-stats|app-install-stats|package-stats|codespace-stats|migration-audit|combine)
+          repository|organization|project-stats|app-install-stats|package-stats|codespace-stats|migration-audit|org-repos|combine)
             echo "✓ Valid type: ${INPUT_TYPE}"
             ;;
           *)
-            echo "::error::Invalid type '${INPUT_TYPE}'. Must be one of: repository, organization, project-stats, app-install-stats, package-stats, codespace-stats, migration-audit, combine."
+            echo "::error::Invalid type '${INPUT_TYPE}'. Must be one of: repository, organization, project-stats, app-install-stats, package-stats, codespace-stats, migration-audit, org-repos, combine."
             exit 1
             ;;
         esac
@@ -332,7 +344,7 @@ runs:
         echo "✓ App install stats authentication validated"
 
     - name: Validate Organization Exists
-      if: ${{ inputs.type == 'organization' || inputs.type == 'project-stats' || inputs.type == 'app-install-stats' || inputs.type == 'package-stats' || inputs.type == 'codespace-stats' || inputs.type == 'migration-audit' }}
+      if: ${{ inputs.type == 'organization' || inputs.type == 'project-stats' || inputs.type == 'app-install-stats' || inputs.type == 'package-stats' || inputs.type == 'codespace-stats' || inputs.type == 'migration-audit' || inputs.type == 'org-repos' }}
       shell: bash
       env:
         GH_TOKEN: ${{ steps.app-install.outputs.token || inputs.access-token || inputs.github-token }}
@@ -390,6 +402,56 @@ runs:
         gh migration-audit --version
 
         echo "✓ Dependencies installed successfully"
+
+    # --- org-repos: list repos + compute batch matrix ---
+    - name: List Organization Repositories
+      id: org-repos
+      if: ${{ inputs.type == 'org-repos' }}
+      shell: bash
+      env:
+        BATCH_SIZE: ${{ inputs.batch-size }}
+      run: |
+        ORG_REPOS_ARGS=(
+          --org-name "${{ inputs.organization }}"
+          --base-url "${{ inputs.base-url }}"
+          --output-dir "${{ steps.setup-paths.outputs.output_dir }}"
+          --save-repo-list
+          --output-file-name "${{ github.workspace }}/repos.txt"
+        )
+
+        # Auth: prefer app installation, then access-token
+        if [[ -n "${{ inputs.github-app-id }}" ]] && [[ -n "${{ inputs.github-app-private-key }}" ]]; then
+          ORG_REPOS_ARGS+=(--app-id "${{ inputs.github-app-id }}")
+          ORG_REPOS_ARGS+=(--private-key "${{ inputs.github-app-private-key }}")
+          if [[ -n "${{ steps.app-install.outputs.installation-id }}" ]]; then
+            ORG_REPOS_ARGS+=(--app-installation-id "${{ steps.app-install.outputs.installation-id }}")
+          fi
+        elif [[ -n "${{ inputs.access-token }}" ]]; then
+          ORG_REPOS_ARGS+=(--access-token "${{ inputs.access-token }}")
+        fi
+
+        if [[ -n "${BATCH_SIZE}" ]]; then
+          [[ "${BATCH_SIZE}" =~ ^[0-9]+$ ]] && [[ "${BATCH_SIZE}" -ge 1 ]] || { echo "::error::batch-size must be a positive integer"; exit 1; }
+          ORG_REPOS_ARGS+=(--batch-size "${BATCH_SIZE}")
+        fi
+
+        OUTPUT=$(gh repo-stats-plus org-repos "${ORG_REPOS_ARGS[@]}")
+
+        # Extract repo count from stdout
+        REPO_COUNT=$(echo "${OUTPUT}" | grep -c '/' || echo "0")
+        echo "repo_count=${REPO_COUNT}" >> "$GITHUB_OUTPUT"
+        echo "repo_list_file=${{ github.workspace }}/repos.txt" >> "$GITHUB_OUTPUT"
+
+        # If batch-size was provided, parse the matrix from CLI output
+        if [[ -n "${BATCH_SIZE}" ]]; then
+          MATRIX_LINE=$(echo "${OUTPUT}" | grep '  Matrix:' | sed 's/.*Matrix: *//')
+          BATCH_SIZE_LINE=$(echo "${OUTPUT}" | grep '  Batch size:' | sed 's/.*Batch size: *//')
+          echo "matrix=${MATRIX_LINE}" >> "$GITHUB_OUTPUT"
+          echo "batch_size=${BATCH_SIZE_LINE}" >> "$GITHUB_OUTPUT"
+          echo "✅ Batch matrix computed: ${REPO_COUNT} repos"
+        fi
+
+        echo "✅ Listed ${REPO_COUNT} repos for ${{ inputs.organization }}"
 
     - name: Resolve Resume Mode
       id: resolve-resume


### PR DESCRIPTION
## Summary

Wires the new `org-repos` CLI subcommand (#193) as a supported `type` in the GitHub Action. Callers can now use:

```yaml
- uses: mona-actions/gh-repo-stats-plus@...
  with:
    type: org-repos
    organization: my-org
    batch-size: 50
    # ...auth inputs...
```

This replaces ad-hoc shell scripts (`gh api` + `curl`) in caller workflows that could not handle rate limits properly. The action leverages the existing Octokit-based GraphQL paginator with built-in rate-limit handling.

## Changes

- Added `org-repos` to the valid `type` enum in input validation
- Added `org-repos` to the Validate Organization Exists condition
- Added new outputs: `matrix`, `batch_size`, `repo_count`, `repo-list-file`
- Added `List Organization Repositories` step that invokes `gh repo-stats-plus org-repos` with auth, batch-size, and save-repo-list options
- Existing steps unaffected (all filter by their specific types)

## Related

- Builds on #193 (`org-repos` CLI subcommand)
- Follow-up: update caller workflows to use `type: org-repos` instead of shell-based repo enumeration