### PR TITLE
fix: skip combine-stats when fewer than 2 CSV files exist

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -863,10 +863,11 @@ runs:
         OUTPUT_DIR: ${{ steps.setup-paths.outputs.output_dir }}
       run: |
         # Collect CSV files into an array to handle 0 or 1 match gracefully
+        # Sort the discovered paths so combine order is deterministic.
         CSV_FILES=()
         while IFS= read -r -d '' f; do
           CSV_FILES+=("$f")
-        done < <(find "${OUTPUT_DIR}" -maxdepth 1 -name "*.csv" -print0 2>/dev/null)
+        done < <(find "${OUTPUT_DIR}" -maxdepth 1 -name "*.csv" -print0 2>/dev/null | sort -z)
 
         CSV_COUNT=${#CSV_FILES[@]}
 

--- a/action.yml
+++ b/action.yml
@@ -871,7 +871,7 @@ runs:
         CSV_COUNT=${#CSV_FILES[@]}
 
         if [[ ${CSV_COUNT} -lt 2 ]]; then
-          echo "⚠ Found ${CSV_COUNT} CSV file(s) in ${OUTPUT_DIR} — at least 2 are required to combine. Skipping combine step."
+          echo "::warning::Found ${CSV_COUNT} CSV file(s) in ${OUTPUT_DIR} - at least 2 are required to combine. Skipping combine step."
           exit 0
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -862,8 +862,21 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         OUTPUT_DIR: ${{ steps.setup-paths.outputs.output_dir }}
       run: |
+        # Collect CSV files into an array to handle 0 or 1 match gracefully
+        CSV_FILES=()
+        while IFS= read -r -d '' f; do
+          CSV_FILES+=("$f")
+        done < <(find "${OUTPUT_DIR}" -maxdepth 1 -name "*.csv" -print0 2>/dev/null)
+
+        CSV_COUNT=${#CSV_FILES[@]}
+
+        if [[ ${CSV_COUNT} -lt 2 ]]; then
+          echo "⚠ Found ${CSV_COUNT} CSV file(s) in ${OUTPUT_DIR} — at least 2 are required to combine. Skipping combine step."
+          exit 0
+        fi
+
         gh repo-stats-plus combine-stats \
-          --files "${OUTPUT_DIR}"/*.csv \
+          --files "${CSV_FILES[@]}" \
           --output-dir "${OUTPUT_DIR}" \
           --output-file-name combined-stats.csv
 


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

When collection jobs (e.g., `repo-stats-collect`, `project-stats-collect`) run against an organization with 0 repositories or 0 matching batches, the output directory ends up with 0 or 1 CSV files. The `Combine Stats` step was using a bare shell glob (`${OUTPUT_DIR}/*.csv`) to pass files to `combine-stats`, which expands to either the literal string `*.csv` (no matches) or a single path -- both cases fail the command's minimum-2-files validation with an unhandled error and a non-zero exit code.

The fix replaces the bare glob with a `find`-based array build that correctly counts matched files before invoking the command. If fewer than 2 CSVs are found, the step exits `0` with a clear warning instead of failing the entire workflow run.

**Key changes in `action.yml`:**
- Uses `find -print0` + a `while read` loop to safely collect CSV paths into a bash array (also handles filenames with spaces)
- Checks the count before calling `combine-stats` -- skips gracefully with a `warning` message when < 2 files are present
- Passes `"${CSV_FILES[@]}"` (array expansion) to `--files` instead of a glob, ensuring correct shell word splitting

## Checklist

- [ ] Issue linked if existing
- [x] Add a label to the pull request that indicates the type of change (e.g., `major`, `minor`, `patch`, `enhancement`, `bug`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

The failure was observed in a workflow where both collection jobs reported `(0)` batches, leaving the output directory without enough CSV files for the combine step. This is a valid and expected runtime scenario (e.g., an org with no repos matching the filter), so the workflow should complete successfully rather than error out.