### PR TITLE
skip retries if repo is not found

### DIFF
--- a/__tests__/errors.test.ts
+++ b/__tests__/errors.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatErrorMessage,
+  hasStatus,
+  isGitHubNotFoundError,
+} from '../src/errors.js';
+
+describe('formatErrorMessage', () => {
+  it('extracts message from Error instances', () => {
+    expect(formatErrorMessage(new Error('something broke'))).toBe(
+      'something broke',
+    );
+  });
+
+  it('converts non-Error values to strings', () => {
+    expect(formatErrorMessage('string error')).toBe('string error');
+    expect(formatErrorMessage(42)).toBe('42');
+    expect(formatErrorMessage(null)).toBe('null');
+  });
+});
+
+describe('hasStatus', () => {
+  it('returns true when error has matching numeric status', () => {
+    const error = Object.assign(new Error('fail'), { status: 404 });
+    expect(hasStatus(error, 404)).toBe(true);
+  });
+
+  it('returns false for mismatched status', () => {
+    const error = Object.assign(new Error('fail'), { status: 500 });
+    expect(hasStatus(error, 404)).toBe(false);
+  });
+
+  it('returns false for non-numeric status', () => {
+    const error = Object.assign(new Error('fail'), { status: '404' });
+    expect(hasStatus(error, 404)).toBe(false);
+  });
+
+  it('returns false for errors without status', () => {
+    expect(hasStatus(new Error('fail'), 404)).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(hasStatus(null, 404)).toBe(false);
+    expect(hasStatus(undefined, 404)).toBe(false);
+    expect(hasStatus('string', 404)).toBe(false);
+  });
+});
+
+describe('isGitHubNotFoundError', () => {
+  it('detects HTTP 404 status', () => {
+    const error = Object.assign(new Error('Not Found'), { status: 404 });
+    expect(isGitHubNotFoundError(error)).toBe(true);
+  });
+
+  it('detects structured GraphQL NOT_FOUND type', () => {
+    const error = Object.assign(new Error('GraphQL error'), {
+      errors: [
+        {
+          type: 'NOT_FOUND',
+          path: ['repository'],
+          message:
+            "Could not resolve to a Repository with the name 'owner/repo'.",
+        },
+      ],
+    });
+    expect(isGitHubNotFoundError(error)).toBe(true);
+  });
+
+  it('detects GraphQL NOT_FOUND type even without familiar message', () => {
+    const error = Object.assign(new Error('Something unexpected'), {
+      errors: [{ type: 'NOT_FOUND', message: 'Resource not found' }],
+    });
+    expect(isGitHubNotFoundError(error)).toBe(true);
+  });
+
+  it('falls back to message matching when no structured type', () => {
+    const error = new Error(
+      "Request failed due to following response errors:\n - Could not resolve to a Repository with the name 'owner/repo'.",
+    );
+    expect(isGitHubNotFoundError(error)).toBe(true);
+  });
+
+  it('returns false for non-404 HTTP errors', () => {
+    const error = Object.assign(new Error('Server Error'), { status: 500 });
+    expect(isGitHubNotFoundError(error)).toBe(false);
+  });
+
+  it('returns false for GraphQL errors with different type', () => {
+    const error = Object.assign(new Error('Forbidden'), {
+      errors: [{ type: 'FORBIDDEN', message: 'Not allowed' }],
+    });
+    expect(isGitHubNotFoundError(error)).toBe(false);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isGitHubNotFoundError(new Error('Network timeout'))).toBe(false);
+    expect(isGitHubNotFoundError('string error')).toBe(false);
+  });
+
+  it('handles errors with empty errors array', () => {
+    const error = Object.assign(new Error('Empty errors'), { errors: [] });
+    expect(isGitHubNotFoundError(error)).toBe(false);
+  });
+});

--- a/__tests__/repo-list-execution.test.ts
+++ b/__tests__/repo-list-execution.test.ts
@@ -161,6 +161,12 @@ describe('standalone repo-list execution', () => {
     mockClient.getRepoStats.mockImplementation((owner: string, repo: string) =>
       Promise.resolve(createRepo(owner, repo)),
     );
+    mockClient.checkRateLimits.mockResolvedValue({
+      graphQLRemaining: 5000,
+      apiRemainingRequest: 5000,
+      messageType: 'info',
+      message: 'Rate limits OK',
+    });
   });
 
   it('processes multi-owner repo lists into one combined CSV/state namespace', async () => {
@@ -358,6 +364,331 @@ describe('standalone repo-list execution', () => {
       processedRepos: [],
       updates: {},
     });
+  });
+
+  it('skips not-found repo-list entries and continues processing later repositories', async () => {
+    const { run } = await import('../src/main.js');
+    const { appendFileSync } = await import('fs');
+
+    mockClient.getRepoStats.mockImplementation(
+      (owner: string, repo: string) => {
+        if (repo === 'Missing') {
+          return Promise.reject(
+            Object.assign(new Error('Not Found'), { status: 404 }),
+          );
+        }
+
+        return Promise.resolve(createRepo(owner, repo));
+      },
+    );
+
+    const result = await run(
+      createArgs({
+        repoList: ['OwnerA/RepoOne', 'OwnerA/Missing', 'OwnerA/RepoTwo'],
+        outputFileName: 'combined.csv',
+      }),
+    );
+
+    expect(result).toEqual(['combined.csv']);
+    expect(mockClient.getRepoStats).toHaveBeenCalledTimes(3);
+    expect(mockClient.getRepoStats).toHaveBeenNthCalledWith(
+      3,
+      'OwnerA',
+      'RepoTwo',
+      10,
+    );
+    expect(appendFileSync).toHaveBeenCalledTimes(2);
+    expect(
+      mockStateUpdate.mock.calls
+        .map(
+          ([, updates]: [ProcessedPageState, { repoName?: string }]) =>
+            updates.repoName,
+        )
+        .filter(Boolean),
+    ).toEqual(['ownera/repoone', 'ownera/repotwo']);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Skipping repository OwnerA/Missing because it was not found or is inaccessible: Not Found',
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('Retry attempt'),
+    );
+  });
+
+  it('skips GraphQL repository resolution failures during initial lookup', async () => {
+    const { run } = await import('../src/main.js');
+    const { appendFileSync } = await import('fs');
+    const graphqlNotFoundError = new Error(
+      "Request failed due to following response errors:\n - Could not resolve to a Repository with the name 'Compliance-R/compprocessnodeweb'.",
+    );
+
+    mockClient.getRepoStats.mockImplementation(
+      (owner: string, repo: string) => {
+        if (repo === 'compprocessnodeweb') {
+          return Promise.reject(graphqlNotFoundError);
+        }
+
+        return Promise.resolve(createRepo(owner, repo));
+      },
+    );
+
+    const result = await run(
+      createArgs({
+        repoList: ['Compliance-R/compprocessnodeweb', 'Compliance-R/next-repo'],
+        outputFileName: 'combined.csv',
+      }),
+    );
+
+    expect(result).toEqual(['combined.csv']);
+    expect(mockClient.getRepoStats).toHaveBeenCalledTimes(2);
+    expect(appendFileSync).toHaveBeenCalledTimes(1);
+    expect(
+      mockStateUpdate.mock.calls
+        .map(
+          ([, updates]: [ProcessedPageState, { repoName?: string }]) =>
+            updates.repoName,
+        )
+        .filter(Boolean),
+    ).toEqual(['compliance-r/next-repo']);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      `Skipping repository Compliance-R/compprocessnodeweb because it was not found or is inaccessible: ${graphqlNotFoundError.message}`,
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('Retry attempt'),
+    );
+  });
+
+  it('does not retry same-run not-found entries during auto missing processing', async () => {
+    const { run } = await import('../src/main.js');
+    const { appendFileSync } = await import('fs');
+    const { readCsvFile } = await import('../src/csv.js');
+
+    mockClient.getRepoStats.mockImplementation(
+      (owner: string, repo: string) => {
+        if (repo === 'Missing') {
+          return Promise.reject(
+            Object.assign(new Error('Not Found'), { status: 404 }),
+          );
+        }
+
+        return Promise.resolve(createRepo(owner, repo));
+      },
+    );
+    vi.mocked(readCsvFile).mockReturnValue([
+      { Org_Name: 'OwnerA', Repo_Name: 'RepoOne' },
+      { Org_Name: 'OwnerA', Repo_Name: 'RepoTwo' },
+    ]);
+
+    const result = await run(
+      createArgs({
+        repoList: ['OwnerA/RepoOne', 'OwnerA/Missing', 'OwnerA/RepoTwo'],
+        outputFileName: 'combined.csv',
+        autoProcessMissing: true,
+      }),
+    );
+
+    expect(result).toEqual(['combined.csv']);
+    expect(mockClient.getRepoStats).toHaveBeenCalledTimes(3);
+    expect(
+      mockClient.getRepoStats.mock.calls.filter(
+        ([, repo]) => repo === 'Missing',
+      ),
+    ).toHaveLength(1);
+    expect(appendFileSync).toHaveBeenCalledTimes(2);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'No retryable missing repo-list repositories found. Skipped 1 repositories that were not found or inaccessible earlier in this run.',
+    );
+  });
+
+  it('retries status-bearing non-404 repo-list failures', async () => {
+    const { run } = await import('../src/main.js');
+
+    mockClient.getRepoStats
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Server Error'), { status: 500 }),
+      )
+      .mockImplementation((owner: string, repo: string) =>
+        Promise.resolve(createRepo(owner, repo)),
+      );
+    mockWithRetry.mockImplementationOnce(
+      async (operation, _config, onRetry) => {
+        try {
+          return await operation();
+        } catch (error) {
+          onRetry?.({
+            attempt: 1,
+            successCount: 0,
+            retryCount: 1,
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+          return await operation();
+        }
+      },
+    );
+
+    await run(createArgs({ repoList: ['OwnerA/RepoOne'] }));
+
+    expect(mockClient.getRepoStats).toHaveBeenCalledTimes(2);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Failed processing repo OwnerA/RepoOne: Server Error',
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Retry attempt 1: Failed while processing repo-list.',
+      ),
+    );
+  });
+
+  it('does not skip downstream analysis-stage 404 failures after repository lookup succeeds', async () => {
+    const { run } = await import('../src/main.js');
+
+    mockClient.checkRateLimits.mockRejectedValue(
+      Object.assign(new Error('Not Found'), { status: 404 }),
+    );
+    mockWithRetry.mockImplementationOnce(
+      async (operation, _config, onRetry) => {
+        try {
+          return await operation();
+        } catch (error) {
+          onRetry?.({
+            attempt: 1,
+            successCount: 0,
+            retryCount: 1,
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+          throw error;
+        }
+      },
+    );
+
+    await expect(
+      run(
+        createArgs({
+          repoList: ['OwnerA/RepoOne'],
+          rateLimitCheckInterval: 1,
+        }),
+      ),
+    ).rejects.toThrow('Not Found');
+
+    expect(mockClient.getRepoStats).toHaveBeenCalledTimes(1);
+    expect(mockClient.checkRateLimits).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Failed processing repo OwnerA/RepoOne: Not Found',
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Retry attempt 1: Failed while processing repo-list.',
+      ),
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      'Skipping repository OwnerA/RepoOne because it was not found or is inaccessible: Not Found',
+    );
+  });
+
+  it('does not re-query not-found repos when a sibling repo triggers a retry', async () => {
+    const { run } = await import('../src/main.js');
+    const { appendFileSync } = await import('fs');
+
+    let repoOneCallCount = 0;
+    mockClient.getRepoStats.mockImplementation(
+      (owner: string, repo: string) => {
+        if (repo === 'Missing') {
+          return Promise.reject(
+            Object.assign(new Error('Not Found'), { status: 404 }),
+          );
+        }
+        if (repo === 'Flaky') {
+          repoOneCallCount++;
+          if (repoOneCallCount === 1) {
+            return Promise.reject(
+              Object.assign(new Error('Server Error'), { status: 500 }),
+            );
+          }
+        }
+        return Promise.resolve(createRepo(owner, repo));
+      },
+    );
+
+    mockWithRetry.mockImplementationOnce(
+      async (operation, _config, onRetry) => {
+        try {
+          return await operation();
+        } catch (error) {
+          onRetry?.({
+            attempt: 1,
+            successCount: 0,
+            retryCount: 1,
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+          return await operation();
+        }
+      },
+    );
+
+    const result = await run(
+      createArgs({
+        repoList: ['OwnerA/Missing', 'OwnerA/Flaky'],
+        outputFileName: 'combined.csv',
+      }),
+    );
+
+    expect(result).toEqual(['combined.csv']);
+    // Missing should only be called once (skipped on retry via skippedNotFoundRepoKeys)
+    expect(
+      mockClient.getRepoStats.mock.calls.filter(
+        ([, repo]) => repo === 'Missing',
+      ),
+    ).toHaveLength(1);
+    // Flaky should be called twice (once failing, once succeeding on retry)
+    expect(
+      mockClient.getRepoStats.mock.calls.filter(([, repo]) => repo === 'Flaky'),
+    ).toHaveLength(2);
+    expect(appendFileSync).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping repository OwnerA/Missing'),
+    );
+  });
+
+  it('skips repos with structured GraphQL NOT_FOUND error type', async () => {
+    const { run } = await import('../src/main.js');
+    const { appendFileSync } = await import('fs');
+
+    const graphqlNotFoundError = Object.assign(
+      new Error(
+        "Request failed due to following response errors:\n - Could not resolve to a Repository with the name 'OwnerA/Missing'.",
+      ),
+      {
+        errors: [
+          {
+            type: 'NOT_FOUND',
+            path: ['repository'],
+            message:
+              "Could not resolve to a Repository with the name 'OwnerA/Missing'.",
+          },
+        ],
+      },
+    );
+
+    mockClient.getRepoStats.mockImplementation(
+      (owner: string, repo: string) => {
+        if (repo === 'Missing') {
+          return Promise.reject(graphqlNotFoundError);
+        }
+        return Promise.resolve(createRepo(owner, repo));
+      },
+    );
+
+    const result = await run(
+      createArgs({
+        repoList: ['OwnerA/Missing', 'OwnerA/RepoOne'],
+        outputFileName: 'combined.csv',
+      }),
+    );
+
+    expect(result).toEqual(['combined.csv']);
+    expect(appendFileSync).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping repository OwnerA/Missing'),
+    );
   });
 
   it('rejects multi-owner repo-list runs with GitHub App installation auth', async () => {

--- a/__tests__/repo-list-execution.test.ts
+++ b/__tests__/repo-list-execution.test.ts
@@ -588,7 +588,7 @@ describe('standalone repo-list execution', () => {
     const { run } = await import('../src/main.js');
     const { appendFileSync } = await import('fs');
 
-    let repoOneCallCount = 0;
+    let flakyCallCount = 0;
     mockClient.getRepoStats.mockImplementation(
       (owner: string, repo: string) => {
         if (repo === 'Missing') {
@@ -597,8 +597,8 @@ describe('standalone repo-list execution', () => {
           );
         }
         if (repo === 'Flaky') {
-          repoOneCallCount++;
-          if (repoOneCallCount === 1) {
+          flakyCallCount++;
+          if (flakyCallCount === 1) {
             return Promise.reject(
               Object.assign(new Error('Server Error'), { status: 500 }),
             );

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,7 +74,7 @@ gh repo-stats-plus repo-stats --org-name my-org --auto-process-missing
 gh repo-stats-plus repo-stats --repo-list repos-to-process.txt --auto-process-missing
 ```
 
-For standalone repo-list mode, `--auto-process-missing` compares requested `owner/repo` keys to the combined CSV `Org_Name` and `Repo_Name` columns. Organization-based missing-repo behavior is unchanged.
+For standalone repo-list mode, `--auto-process-missing` compares requested `owner/repo` keys to the combined CSV `Org_Name` and `Repo_Name` columns.
 
 ### Count Project Associations
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared error utility functions for consistent error handling across the application.
+ */
+
+export function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function hasStatus(error: unknown, status: number): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    typeof error.status === 'number' &&
+    error.status === status
+  );
+}
+
+interface GraphQLError {
+  type?: string;
+  message?: string;
+}
+
+function hasGraphQLErrors(error: unknown): error is { errors: GraphQLError[] } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'errors' in error &&
+    Array.isArray((error as { errors: unknown }).errors)
+  );
+}
+
+/**
+ * Determines if an error represents a GitHub not-found condition.
+ * Checks in order:
+ * 1. HTTP 404 status on the error object (REST API)
+ * 2. Structured GraphQL error type 'NOT_FOUND' (preferred for GraphQL)
+ * 3. GraphQL message containing 'Could not resolve to a Repository' (fallback)
+ */
+export function isGitHubNotFoundError(error: unknown): boolean {
+  if (hasStatus(error, 404)) {
+    return true;
+  }
+
+  if (
+    hasGraphQLErrors(error) &&
+    error.errors.some((e) => e.type === 'NOT_FOUND')
+  ) {
+    return true;
+  }
+
+  const message = formatErrorMessage(error);
+  return message.includes('Could not resolve to a Repository with the name');
+}

--- a/src/repo-list-service.ts
+++ b/src/repo-list-service.ts
@@ -12,15 +12,18 @@ import {
 } from './repo-list.js';
 import {
   buildProcessedRepoKeySet,
+  fetchRepositoryStatsByName,
   initializeCsvFile,
-  processRepositoryByName,
+  processFetchedRepositoryStats,
 } from './repo-stats-service.js';
+import { formatErrorMessage, isGitHubNotFoundError } from './errors.js';
 import type {
   Arguments,
   CommandContext,
   CommandResult,
   Logger,
   ProcessedPageState,
+  RepositoryStats,
 } from './types.js';
 import type { OctokitClient } from './service.js';
 import type { RetryConfig } from './retry.js';
@@ -92,6 +95,7 @@ export async function processRepoListSource(
     processedCount: 0,
   };
   const processedRepoKeys = buildProcessedRepoKeySet(processedState);
+  const skippedNotFoundRepoKeys = new Set<string>();
   const startTime = new Date();
 
   await withRetry(
@@ -109,6 +113,7 @@ export async function processRepoListSource(
           state: processingState,
           fileName,
           stateManager,
+          skippedNotFoundRepoKeys,
         });
       }
 
@@ -146,6 +151,7 @@ export async function processRepoListSource(
       retryConfig,
       fileName,
       stateManager,
+      skippedNotFoundRepoKeys,
     });
   }
 
@@ -209,6 +215,7 @@ export async function processMissingRepoListRepositories({
   retryConfig,
   fileName,
   stateManager,
+  skippedNotFoundRepoKeys,
 }: {
   opts: Arguments;
   normalizedRepoList: NormalizedRepoList;
@@ -219,12 +226,16 @@ export async function processMissingRepoListRepositories({
   retryConfig: RetryConfig;
   fileName: string;
   stateManager: StateManager;
+  skippedNotFoundRepoKeys: Set<string>;
 }): Promise<void> {
   logger.info('Checking for missing repositories from --repo-list output...');
   const missingEntries = findMissingRepoListEntries({
     normalizedRepoList,
     processedFile: fileName,
   });
+  const missingEntriesToProcess = missingEntries.filter(
+    (entry) => !skippedNotFoundRepoKeys.has(entry.key),
+  );
 
   if (missingEntries.length === 0) {
     logger.info(
@@ -233,13 +244,21 @@ export async function processMissingRepoListRepositories({
     return;
   }
 
+  if (missingEntriesToProcess.length === 0) {
+    logger.info(
+      `No retryable missing repo-list repositories found. Skipped ${missingEntries.length} ` +
+        'repositories that were not found or inaccessible earlier in this run.',
+    );
+    return;
+  }
+
   logger.info(
-    `Found ${missingEntries.length} missing repo-list repositories that need to be processed`,
+    `Found ${missingEntriesToProcess.length} missing repo-list repositories that need to be processed`,
   );
   processedState.completedSuccessfully = false;
   stateManager.update(processedState, {});
 
-  for (const entry of missingEntries) {
+  for (const entry of missingEntriesToProcess) {
     processedRepoKeys.delete(entry.key);
   }
 
@@ -253,7 +272,7 @@ export async function processMissingRepoListRepositories({
     async () => {
       let processedCount = 0;
       for (const ownerGroup of groupRepoListEntriesForProcessing(
-        missingEntries,
+        missingEntriesToProcess,
       )) {
         processedCount += await processRepoListOwnerGroup({
           ownerGroup,
@@ -265,6 +284,7 @@ export async function processMissingRepoListRepositories({
           state: missingProcessingState,
           fileName,
           stateManager,
+          skippedNotFoundRepoKeys,
         });
       }
 
@@ -298,6 +318,7 @@ export async function processRepoListOwnerGroup({
   state,
   fileName,
   stateManager,
+  skippedNotFoundRepoKeys,
 }: {
   ownerGroup: RepoListOwnerGroup;
   client: OctokitClient;
@@ -308,6 +329,7 @@ export async function processRepoListOwnerGroup({
   state: { successCount: number; retryCount: number; processedCount: number };
   fileName: string;
   stateManager: StateManager;
+  skippedNotFoundRepoKeys: Set<string>;
 }): Promise<number> {
   logger.info(
     `Processing ${ownerGroup.entries.length} repositories for owner ${ownerGroup.owner}`,
@@ -320,9 +342,46 @@ export async function processRepoListOwnerGroup({
       continue;
     }
 
+    if (skippedNotFoundRepoKeys.has(entry.key)) {
+      logger.debug(
+        `Skipping repository already marked not found or inaccessible: ${entry.key}`,
+      );
+      continue;
+    }
+
+    const processedCountForAttempt = state.processedCount + 1;
+    let repoStats: RepositoryStats;
     try {
-      await processRepositoryByName({
+      repoStats = await fetchRepositoryStatsByName({
         entry,
+        client,
+        opts,
+      });
+    } catch (error) {
+      if (isGitHubNotFoundError(error)) {
+        skippedNotFoundRepoKeys.add(entry.key);
+        logger.warn(
+          `Skipping repository ${entry.owner}/${entry.repo} because it was not found or is inaccessible: ${formatErrorMessage(error)}`,
+        );
+        continue;
+      }
+
+      state.successCount = 0;
+      logger.error(
+        `Failed processing repo ${entry.owner}/${entry.repo}: ${formatErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+
+    // Only increment after successful fetch so skipped repos don't consume rate-limit check slots
+    state.processedCount = processedCountForAttempt;
+
+    try {
+      await processFetchedRepositoryStats({
+        entry,
+        repoStats,
         client,
         logger,
         opts,
@@ -331,15 +390,15 @@ export async function processRepoListOwnerGroup({
         state,
         fileName,
         stateManager,
-        processedCount: ++state.processedCount,
+        processedCount: processedCountForAttempt,
       });
       processedCount += 1;
     } catch (error) {
       state.successCount = 0;
       logger.error(
-        `Failed processing repo ${entry.owner}/${entry.repo}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Failed processing repo ${entry.owner}/${entry.repo}: ${formatErrorMessage(
+          error,
+        )}`,
       );
       throw error;
     }

--- a/src/repo-stats-service.ts
+++ b/src/repo-stats-service.ts
@@ -21,6 +21,7 @@ import {
   initializeCsvFile as initializeCsvFileGeneric,
   REPO_STATS_COLUMNS,
 } from './csv.js';
+import { formatErrorMessage } from './errors.js';
 
 export interface RepoStatsRepositoryEntry {
   owner: string;
@@ -162,12 +163,64 @@ export async function processRepositoryByName({
 }): Promise<void> {
   logger.info(`Processing repository: ${entry.owner}/${entry.repo}`);
 
-  const repoStats = await client.getRepoStats(
+  const repoStats = await fetchRepositoryStatsByName({ entry, client, opts });
+
+  await processFetchedRepositoryStats({
+    entry,
+    repoStats,
+    client,
+    logger,
+    opts,
+    processedState,
+    processedRepoKeys,
+    state,
+    fileName,
+    stateManager,
+    processedCount,
+  });
+}
+
+export async function fetchRepositoryStatsByName({
+  entry,
+  client,
+  opts,
+}: {
+  entry: RepoStatsRepositoryEntry;
+  client: OctokitClient;
+  opts: Arguments;
+}): Promise<RepositoryStats> {
+  return client.getRepoStats(
     entry.owner,
     entry.repo,
     opts.pageSize != null ? Number(opts.pageSize) : 10,
   );
+}
 
+export async function processFetchedRepositoryStats({
+  entry,
+  repoStats,
+  client,
+  logger,
+  opts,
+  processedState,
+  processedRepoKeys,
+  state,
+  fileName,
+  stateManager,
+  processedCount,
+}: {
+  entry: RepoStatsRepositoryEntry;
+  repoStats: RepositoryStats;
+  client: OctokitClient;
+  logger: Logger;
+  opts: Arguments;
+  processedState: ProcessedPageState;
+  processedRepoKeys: Set<string>;
+  state: RepoStatsProcessingState;
+  fileName: string;
+  stateManager: StateManager;
+  processedCount: number;
+}): Promise<void> {
   const result = await analyzeRepositoryStats({
     repo: repoStats,
     owner: entry.owner,
@@ -322,9 +375,7 @@ export async function writeResultToCsv(
     );
   } catch (error) {
     logger.error(
-      `Failed to write CSV for repository ${result.Repo_Name}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
+      `Failed to write CSV for repository ${result.Repo_Name}: ${formatErrorMessage(error)}`,
     );
     throw error;
   }


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

This pull request introduces robust error handling for not-found repositories in standalone repo-list processing, ensuring that repositories which cannot be found (due to HTTP 404 or GraphQL "NOT_FOUND" errors) are gracefully skipped and not retried within the same run. It also adds comprehensive tests for these scenarios, centralizes error handling logic, and updates documentation to reflect the clarified behavior.

## Checklist

- [ ] Issue linked if existing
- [x] Add a label to the pull request that indicates the type of change (e.g., `major`, `minor`, `patch`, `enhancement`, `bug`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

**Error handling improvements:**

* Added new utility functions in `src/errors.ts` for formatting error messages, checking HTTP status codes, and reliably detecting GitHub not-found errors, including both REST (404) and GraphQL (NOT_FOUND) cases.
* Updated imports in `src/repo-list-service.ts` to use the new error utility functions for consistent error handling.

**Repo-list processing logic:**

* Enhanced the repo-list processing flow in `src/repo-list-service.ts` to track and skip not-found repositories using a `skippedNotFoundRepoKeys` set, preventing unnecessary retries within the same run. This logic is applied both during initial processing and when handling missing entries with `--auto-process-missing`. [[1]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R98) [[2]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R116) [[3]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R154) [[4]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R218) [[5]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R229-R238) [[6]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R247-R261) [[7]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89L256-R275) [[8]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R287) [[9]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R321) [[10]](diffhunk://#diff-a17542da5aa400ff8d510cdc2087561656b70b94ffbe9bcad58514ec759d1e89R332)

**Testing:**

* Added comprehensive tests in `__tests__/errors.test.ts` for the new error utility functions, covering various error scenarios for REST and GraphQL not-found cases.
* Expanded tests in `__tests__/repo-list-execution.test.ts` to verify that not-found repositories are skipped, not retried, and handled correctly during retries and missing-repo processing. [[1]](diffhunk://#diff-857931c8dc60a5a2d6a53c518f691244490fd41263f4dc88321e9f07edfd9bfaR164-R169) [[2]](diffhunk://#diff-857931c8dc60a5a2d6a53c518f691244490fd41263f4dc88321e9f07edfd9bfaR369-R693)

**Documentation:**

* Updated `docs/usage.md` to clarify the behavior of `--auto-process-missing` in standalone repo-list mode.
